### PR TITLE
Fixed background scrolling color in iOS

### DIFF
--- a/themes/zdoc/assets/sass/base/_reset.scss
+++ b/themes/zdoc/assets/sass/base/_reset.scss
@@ -63,6 +63,7 @@ h5,
 h6 {
   margin: 0;
   padding: 0;
+  overflow-x: hidden; 
 }
 
 // List

--- a/themes/zdoc/layouts/_default/baseof.html
+++ b/themes/zdoc/layouts/_default/baseof.html
@@ -17,6 +17,11 @@
         var localTheme = localStorage.getItem('theme');
         if (localTheme) {
             document.getElementById('root').className = `theme__${localTheme}`;
+            if (localTheme == "dark") {
+                document.body.style.background = "#212121";
+            } else if (localTheme == "light") {    
+                document.body.style.background = "#f7f8f9";
+            }
         }        
     </script>
     


### PR DESCRIPTION
On iOS Safari (And probably other mobile browsers) the background color when scrolling was stark white, even when in dark mode. After poking around in there we now change the background color in the front end JS. (Theme is handled almost entirely JS side so I think that was the best way to go). 