### PR TITLE
Updated Stealth Perm Enum Article

### DIFF
--- a/content/aws/enumeration/stealth_perm_enum.md
+++ b/content/aws/enumeration/stealth_perm_enum.md
@@ -12,7 +12,7 @@ After compromising an IAM credential while attacking AWS, your next task will be
 
 Aside from guessing, enumerating these permissions would typically require a tool to brute force them like [enumerate-iam](https://github.com/andresriancho/enumerate-iam) (which is a fantastic tool). The problem of course is that this will generate a ton of CloudTrail logs and will alert any defender. This poses a challenge to us, how can we enumerate permissions in a stealthy manner?  
 
-The good news is that there is a bug in the AWS API that affects 645 actions across 40 different AWS services. This bug is a result of a mishandling of the Content-Type header, and when that header is malformed in a specific way the results are not logged to CloudTrail. Based on the response codes/body we can determine if the role does or does not have permission to make that API call.
+The good news is that there is a bug in the AWS API that affects 589 actions across 39 different AWS services. This bug is a result of a mishandling of the Content-Type header, and when that header is malformed in a specific way the results are not logged to CloudTrail. Based on the response codes/body we can determine if the role does or does not have permission to make that API call.
 
 The following services are affected, although please note, that not all actions for these services can be enumerated.  
 
@@ -24,20 +24,24 @@ The following services are affected, although please note, that not all actions 
 | codecommit | codepipeline | 
 | codestar | comprehend | 
 | cur | datapipeline | 
-| dax | directconnect | 
-| discovery | forecast |
-| gamelift | health | 
-| identitystore | kinesis | 
-| kinesisanalytics | macie | 
-| mediastore | mgh | 
-| mturk-requester | opsworks-cm | 
-| personalize | redshift-data | 
-| route53domains | route53resolver | 
-| sagemaker | secretsmanager | 
-| shield | sms | 
-| snowball | support | 
-| tagging | textract | 
-| translate | workmail |
+| dax | discovery | 
+| forecast | gamelift | 
+| health | identitystore | 
+| kinesis | kinesisanalytics | 
+| macie | mediastore | 
+| mgh | mturk-requester | 
+| opsworks-cm | personalize | 
+| redshift-data | route53domains | 
+| route53resolver | sagemaker | 
+| secretsmanager | shield | 
+| sms | snowball | 
+| support | tagging | 
+| textract | translate | 
+| workmail |
+
+{{< notice warning "Update" >}}
+As of 12/19/2020, DirectConnect is no longer affected by this bug.
+{{< /notice >}}
 
 {{< notice success "Note" >}}
 For an in depth explanation for the bug, please see the [original research](https://frichetten.com/blog/aws-api-enum-vuln/). In this article we will just discuss how to take advantage of it.


### PR DESCRIPTION
Updated the fact that DirectConnect doesn't appear to be affected anymore, along with the number of services affected