### PR TITLE
Fixed the 'Edit this page' links

### DIFF
--- a/content/aws/avoiding-detection/guardduty-pentest.md
+++ b/content/aws/avoiding-detection/guardduty-pentest.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Bypass GuardDuty Pentest Findings
 description: Prevent Kali Linux, ParrotOS, and Pentoo Linux from throwing GuardDuty alerts by modifying the User Agent string.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 When making AWS API requests on common penetration testing OS's GuardDuty will detect this and trigger a [PenTest Finding](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#pentest-iam-kalilinux).
 

--- a/content/aws/avoiding-detection/guardduty-tor-client.md
+++ b/content/aws/avoiding-detection/guardduty-tor-client.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: "Bypass GuardDuty Tor Client Findings"
 description: "Connect to the Tor network from an EC2 instance without alerting GuardDuty."
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 [UnauthorizedAccess:EC2/TorClient](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#unauthorizedaccess-ec2-torclient) is a high severity GuardDuty finding that fires when an EC2 instance is detected making connections to Tor [Guard](https://community.torproject.org/relay/types-of-relays/#Guard%20and%20middle%20relay) or Authority nodes. According to the documentation, "this finding may indicate unauthorized access to your AWS resources with the intent of hiding the attacker's true identity".
 

--- a/content/aws/avoiding-detection/steal-keys-undetected.md
+++ b/content/aws/avoiding-detection/steal-keys-undetected.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Bypass Credential Exfiltration Detection
 description: When stealing IAM credentials from an EC2 instance you can avoid a GuardDuty detection by using the keys from another EC2 instance.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 A common occurrence while performing penetration testing on AWS is leveraging SSRF, XXE, command injection, etc. to steal IAM credentials from the meta data service. This can allow you to execute API calls you otherwise wouldn't be able to (especially if you can't get code execution on the EC2 instance), however it comes at a penalty. There is a GuardDuty rule which detects IAM credentials being used outside of EC2 called [IAMUser/InstanceCredentialExfiltration](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#unauthorizedaccess-iam-instancecredentialexfiltration).
 

--- a/content/aws/enumeration/brute_force_iam_permissions.md
+++ b/content/aws/enumeration/brute_force_iam_permissions.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Brute Force IAM Permissions
 description: Brute force the IAM permissions of a user or role to see what you have access to.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Link to Tool: [GitHub](https://github.com/andresriancho/enumerate-iam)
 

--- a/content/aws/enumeration/enum_iam_user_role.md
+++ b/content/aws/enumeration/enum_iam_user_role.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Unauthenticated Enumeration of IAM Users and Roles
 description: Leverage cross account behaviors to enumerate IAM users and roles in a different AWS account without authentication.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Original Research: [Spencer Gietzen](https://rhinosecuritylabs.com/aws/aws-role-enumeration-iam-p2/)
 Link to Tool: [GitHub](https://github.com/Frichetten/enumate_iam_using_bucket_policy)

--- a/content/aws/enumeration/get-account-id-from-keys.md
+++ b/content/aws/enumeration/get-account-id-from-keys.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Get Account ID from AWS Access Keys
 description: During an assessment you may find AWS IAM credentials but not know what account they are associated with. Use this to get the account ID.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 While performing an assessment in AWS it is not uncommon to come across access keys and not know what account they are associated with. If your scope is defined by the AWS account ID, this may pose a problem as you'd likely not want to use them if they are out of scope.
 

--- a/content/aws/enumeration/stealth_perm_enum.md
+++ b/content/aws/enumeration/stealth_perm_enum.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Enumerate Permissions without Logging to CloudTrail
 description: Leverage a bug in the AWS API to enumerate permissions for a role without logging to CloudTrail and alerting the Blue Team.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Original Research: [Nick Frichette](https://frichetten.com/blog/aws-api-enum-vuln/)
 Link to Tool: [aws_stealth_perm_enum](https://github.com/Frichetten/aws_stealth_perm_enum)

--- a/content/aws/enumeration/whoami.md
+++ b/content/aws/enumeration/whoami.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Whoami - Get Principal Name From Keys
 description: During an assessment you may find AWS IAM credentials. Use these tactics to identify the principal of the keys.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 After finding or stealing IAM credentials during an assessment you will need to identify what they are used for, or if they are valid. The most common method for doing so would be the [get-caller-identity](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html) API call. This is beneficial for a few reasons, in particular that it requires no special permissions to call.
 

--- a/content/aws/exploitation/aws-domain-takeover.md
+++ b/content/aws/exploitation/aws-domain-takeover.md
@@ -3,7 +3,7 @@ author = "Nick Frichette"
 title = "AWS Domain Takeover"
 description = ""
 enableEditBtn = true
-editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content"
+editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content"
 draft = true
 +++
 ## Work in Progress

--- a/content/aws/exploitation/cloudfrunt.md
+++ b/content/aws/exploitation/cloudfrunt.md
@@ -3,7 +3,7 @@ author = "Nick Frichette"
 title = "Cloudfrunt"
 description = ""
 enableEditBtn = true
-editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content"
+editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content"
 draft = true
 +++
 ## Work in Progress

--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Steal EC2 Metadata Credentials via SSRF
 description: Old faithful; How to steal IAM Role credentials via the EC2 Metadata service via SSRF.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 One of the most commonly taught tactics in AWS exploitation is the use of Server Side Request Forgery (SSRF) to access the EC2 metadata service.
 

--- a/content/aws/exploitation/escalate-iam-privs.md
+++ b/content/aws/exploitation/escalate-iam-privs.md
@@ -3,7 +3,7 @@ author = "Nick Frichette"
 title = "Escalate IAM Privileges"
 description = "Abuse API Functionality to Escalate Privileges to AdministratorAccess"
 enableEditBtn = true
-editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content"
+editBaseURL = "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content"
 draft = true
 +++
 ## Work in Progress

--- a/content/aws/exploitation/lambda-steal-iam-credentials.md
+++ b/content/aws/exploitation/lambda-steal-iam-credentials.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Steal IAM Credentials and Event Data from Lambda
 description: Leverage file read and SSRF vulnerabilities to steam IAM credentials and event data from Lambda.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 In Lambda, IAM credentials are passed into the function via environment variables. The benefit for the adversary is that these credentials can be leaked via file read vulnerabilities such as [XML External Entity](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_(XXE)) attacks or SSRF that allows the file protocol. This is because "[everything is a file](https://en.wikipedia.org/wiki/Everything_is_a_file)".
 

--- a/content/aws/exploitation/local-priv-esc-mod-instance-att.md
+++ b/content/aws/exploitation/local-priv-esc-mod-instance-att.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: "Local Privilege Escalation: User Data"
 description: Escalate privileges on an EC2 instance by modifying the user-data scripts with modify-instance-attribute.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 weight: 4
 ---
 **Required IAM Permission**: [modify-instance-attribute](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-instance-attribute.html)

--- a/content/aws/exploitation/local-priv-esc-user-data-s3.md
+++ b/content/aws/exploitation/local-priv-esc-user-data-s3.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: "Local Privilege Escalation: User Data 2"
 description: Escalate privileges on an EC2 instance by modifying scripts and packages called by user data.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 weight: 5
 ---
 A common pattern when using EC2 is to define a [user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) script to be run when an instance is first started or after a reboot. These scripts are typically used to install software, download and set a config, etc. Oftentimes the scripts and packages are pulled from S3 and this introduces an opportunity for a developer/ops person to make a mistake.

--- a/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
@@ -3,7 +3,7 @@ author: Houston Hopkins
 title: Simple Route53/Cloudfront/s3 subdomain takeover
 description: Techniques for taking over subdomains or hostnames that use Cloudfront and/or a DNS record to serve content from Amazone S3
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 
 

--- a/content/aws/general-knowledge/connection-tracking.md
+++ b/content/aws/general-knowledge/connection-tracking.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: "Connection Tracking"
 description: "Abuse security group connection tracking to maintain persistence even when security group rules are changed."
 enableEditBtn: true
-editBaseURL: "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content"
+editBaseURL: "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content"
 ---
 Security Groups in AWS have an interesting capability known as [Connection Tracking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html#security-group-connection-tracking). This allows the security groups to track information about the network traffic and allow/deny that traffic based on the Security Group rules.
 

--- a/content/aws/general-knowledge/iam-key-identifiers.md
+++ b/content/aws/general-knowledge/iam-key-identifiers.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: IAM ID Identifiers
 description: Chart of the IAM ID Prefixes.
 enableEditBtn: true
-editBaseURL: "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content"
+editBaseURL: "https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content"
 ---
 Last updated: 12/20/2020
 [Source](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)

--- a/content/aws/general-knowledge/intro_metadata_service.md
+++ b/content/aws/general-knowledge/intro_metadata_service.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Introduction to the Metadata Service
 description: An Introduction to the Metadata Service and how we can use it.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Every EC2 instance has access to something called the instance metadata service (IMDS). This contains (surprise) metadata about that specific EC2 instance.
 

--- a/content/aws/general-knowledge/introduction_user_data.md
+++ b/content/aws/general-knowledge/introduction_user_data.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: Introduction to User Data
 description: An Introduction to User Data and how it is used.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 [Instance user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html) is used to run commands when an EC2 instance is started or rebooted. This can be an excellent source of information for us as attackers. It typically takes the form of a shell script that can be accessed from the EC2 instance.
 

--- a/content/aws/post_exploitation/aws_consoler.md
+++ b/content/aws/post_exploitation/aws_consoler.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: "AWS Consoler"
 description: "Leverage stolen credentials to use the AWS Console."
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Original Research: [Ian Williams](https://blog.netspi.com/gaining-aws-console-access-via-api-keys/)
 Link to Tool: [GitHub](https://github.com/NetSPI/aws_consoler)

--- a/content/aws/post_exploitation/intercept_ssm_communications.md
+++ b/content/aws/post_exploitation/intercept_ssm_communications.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: "Intercept SSM Communications"
 description: "With access to an EC2 instance you can intercept, modify, and spoof SSM communications."
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Original Research: [Nick Frichette](https://frichetten.com/blog/ssm-agent-tomfoolery/)
 Proof of Concept: [GitHub](https://github.com/Frichetten/ssm-agent-research)

--- a/content/aws/post_exploitation/role-chain-juggling.md
+++ b/content/aws/post_exploitation/role-chain-juggling.md
@@ -3,7 +3,7 @@ author: "Nick Frichette"
 title: "Role Chain Juggling"
 description: "Keep your access by chaining assume-role calls."
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 ---
 Original Research: [Daniel Heinsen](https://twitter.com/hotnops)
 Link to Tool: [GitHub](https://github.com/hotnops/AWSRoleJuggler/)

--- a/content/aws/post_exploitation/user_data_script_persistence.md
+++ b/content/aws/post_exploitation/user_data_script_persistence.md
@@ -3,7 +3,7 @@ author: Nick Frichette
 title: User Data Script Persistence
 description: Maintain access to an EC2 instance and it's IAM role via user data scripts.
 enableEditBtn: true
-editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/master/content
+editBaseURL: https://github.com/Hacking-the-Cloud/hackingthe.cloud/blob/main/content
 weight: 4
 ---
 When using EC2 instances a common design pattern is to define a [user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) script to be run when an instance is first started or after a reboot. These scripts are typically used to install software, download a config, etc. Additionally these scripts are run as root or System which makes them even more useful. Should we gain access to an EC2 instance we may be able to persist by abusing user data scripts via two different methods.


### PR DESCRIPTION
Previously we had master as the primary branch, and that has since been changed to main. However the links to edit pages were not changed. Should be good to go now.