### PR TITLE
Added details to the Pass Role EC2 Priv Esc.

### DIFF
--- a/content/aws/exploitation/iam_privilege_escalation.md
+++ b/content/aws/exploitation/iam_privilege_escalation.md
@@ -115,7 +115,7 @@ This can be taken advantage of with the following one-liner:
 
 ![ec2 run-instances one-liner](/images/aws/exploitation/iam_privilege_escalation/ec2_pass_role_one_liner.png)
 
-Some things to note: The instance profile must already exist, and (realistically) it must have greater permissions than the role you have access to. If you also have the ability to create a role, this can be leveraged.
+Some things to note: The instance profile must already exist, and (realistically) it must have greater permissions than the role you have access to. If you also have the ability to create a role, this can be leveraged (although you may as well set the trust policy of that role to one you control at that point). The role that is being passed must have a trust policy allowing the EC2 service to assume it. You cannot pass arbitrary roles to an EC2 instance.
 
 A common misconception about this attack is that an adversary must have access to an existing SSH key, or be able to spawn an SSM session. This is not actually true, you can leverage [user data](https://hackingthe.cloud/aws/general-knowledge/introduction_user_data/) to perform an action on the host. One common example is to have the EC2 instance curl the metadata service, retrieve the IAM credentials, and then send them to an attacker controlled machine using curl.
 


### PR DESCRIPTION
ben11kehoe on Twitter pointed out a detail about trust policies that was omitted before. Added to provide better context/detail.