### PR TITLE
Revert: Removed permissions needed for AWS Consoler

### DIFF
--- a/content/aws/post_exploitation/aws_consoler.md
+++ b/content/aws/post_exploitation/aws_consoler.md
@@ -7,7 +7,8 @@ description: "Leverage stolen credentials to use the AWS Console."
 Original Research: [Ian Williams](https://blog.netspi.com/gaining-aws-console-access-via-api-keys/)  
 Link to Tool: [GitHub](https://github.com/NetSPI/aws_consoler)
 
-__Required IAM Permissions__: sts:GetFederationToken OR sts:AssumeRole.
+!!! Note
+    It is a good idea to install AWS Consoler in a Docker container or other disposable environment. The dependencies on the project may affect your existing AWS CLI install.
 
 When performing an AWS assessment you will likely encounter IAM Credentials. Traditionally, the majority of these that you would find would only be usable from the AWS CLI. Using a tool called [AWS Consoler](https://github.com/NetSPI/aws_consoler) you can create links that will allow you to access the AWS Console. In this example we will walk through gathering credentials and using those credentials along with Consoler to generate a Console link.
 


### PR DESCRIPTION
While the source code made it look like you needed sts:GetFederationToken or sts:AssumeRole permissions, using credentials from a role with 0 policies attached still allowed me to generate a token and view resources.

I also added a note to use a Docker container because it can break your existing AWS CLI install