### PR TITLE
Added note about stolen Lambda credentials

### DIFF
--- a/content/aws/exploitation/lambda-steal-iam-credentials.md
+++ b/content/aws/exploitation/lambda-steal-iam-credentials.md
@@ -18,3 +18,6 @@ IAM credentials can be accessed via reading `/proc/self/environ`.
 In addition to IAM credentials, Lambda functions also have event data that is passed to the function when it is started. This data is made available to the function via the [runtime interface](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html). Unlike IAM credentials, this data is accessible over standard SSRF at `http://localhost:9001/2018-06-01/runtime/invocation/next`.
 
 This will include information about what invoked the Lambda function and may be valuable depending on the context.
+
+!!! Note
+    Unlike IAM credentials associated with EC2 instances, there is no [GuardDuty](/aws/avoiding-detection/steal-keys-undetected/) alert for stolen Lambda credentials.


### PR DESCRIPTION
Created a Lambda function with GuardDuty enabled, used it's creds outside of that Lambda, no GuardDuty alert. I figured this was the case but wanted to test it. This PR includes a not for future reference.