### PR TITLE
Add aws-vault note

### DIFF
--- a/content/aws/post_exploitation/aws_consoler.md
+++ b/content/aws/post_exploitation/aws_consoler.md
@@ -5,10 +5,14 @@ description: "Leverage stolen credentials to use the AWS Console."
 ---
 
 Original Research: [Ian Williams](https://blog.netspi.com/gaining-aws-console-access-via-api-keys/)  
-Link to Tool: [GitHub](https://github.com/NetSPI/aws_consoler)
+Link to Tool: [aws_consoler](https://github.com/NetSPI/aws_consoler)  
+Alternative Tool: [aws-vault](https://github.com/99designs/aws-vault)
+
+!!! Warning
+    It is a good idea to install AWS Consoler in a Docker container or other disposable environment. The dependencies on the project may affect your existing AWS CLI install.
 
 !!! Note
-    It is a good idea to install AWS Consoler in a Docker container or other disposable environment. The dependencies on the project may affect your existing AWS CLI install.
+    AWS Consoler is an excellent tool to convert IAM credentials into an AWS Console session, however it is no longer maintained. As a result, you may prefer to instead use something like [aws-vault](https://github.com/99designs/aws-vault) which can perform a similar functionality. In the future this page may be deprecated in favor of creating a more generalized technique (rather than being tied to a specific tool).
 
 When performing an AWS assessment you will likely encounter IAM Credentials. Traditionally, the majority of these that you would find would only be usable from the AWS CLI. Using a tool called [AWS Consoler](https://github.com/NetSPI/aws_consoler) you can create links that will allow you to access the AWS Console. In this example we will walk through gathering credentials and using those credentials along with Consoler to generate a Console link.
 

--- a/content/aws/post_exploitation/aws_consoler.md
+++ b/content/aws/post_exploitation/aws_consoler.md
@@ -12,7 +12,7 @@ Alternative Tool: [aws-vault](https://github.com/99designs/aws-vault)
     It is a good idea to install AWS Consoler in a Docker container or other disposable environment. The dependencies on the project may affect your existing AWS CLI install.
 
 !!! Note
-    AWS Consoler is an excellent tool to convert IAM credentials into an AWS Console session, however it is no longer maintained. As a result, you may prefer to instead use something like [aws-vault](https://github.com/99designs/aws-vault) which can perform a similar functionality. In the future this page may be deprecated in favor of creating a more generalized technique (rather than being tied to a specific tool).
+    AWS Consoler is an excellent tool to convert IAM credentials into an AWS Console session, however it is no longer maintained. As a result, you may prefer to instead use something like [aws-vault](https://github.com/99designs/aws-vault) (v6.6.0+) which can perform a similar functionality. In the future this page may be deprecated in favor of creating a more generalized technique (rather than being tied to a specific tool).
 
 When performing an AWS assessment you will likely encounter IAM Credentials. Traditionally, the majority of these that you would find would only be usable from the AWS CLI. Using a tool called [AWS Consoler](https://github.com/NetSPI/aws_consoler) you can create links that will allow you to access the AWS Console. In this example we will walk through gathering credentials and using those credentials along with Consoler to generate a Console link.
 


### PR DESCRIPTION
This is in response to https://github.com/Hacking-the-Cloud/hackingthe.cloud/issues/121. Thinking about this more though, It think we may want to scrap this page entirely. Hacking the Cloud should be about techniques, not individual tools. Perhaps in a future update we will remove the aws-consoler page and instead have a 'convert IAM credentials to a console session' page, and just list the two tools there.