### PR TITLE
Added the docs_path config for git-committers

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -15,5 +15,6 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-awesome-pages-plugin
+      - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install mkdocs-git-committers-plugin-2
       - run: mkdocs build

--- a/.github/workflows/deploy_v2.yml
+++ b/.github/workflows/deploy_v2.yml
@@ -21,6 +21,7 @@ jobs:
       - run: sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-awesome-pages-plugin
-      - run: pip install mkdocs-git-committers-plugin-2>=0.4.3
+      - run: pip install mkdocs-git-revision-date-localized-plugin
+      - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install git+https://${{ secrets.GH_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
       - run: mkdocs gh-deploy --force --config-file mkdocs.insiders.yml

--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -3,10 +3,13 @@ plugins:
   - social # Added to .insiders.yml
   - search
   - awesome-pages # non-standard
+  - git-revision-date-localized:
+      enable_creation_date: true
   - git-committers: # non-standard
       repository: Hacking-the-Cloud/hackingthe.cloud
       branch: main
       token: !ENV GH_TOKEN
+      docs_path: /docs/content/
   - minify:
       minify_html: true
       minify_js: true


### PR DESCRIPTION
I'm a litle salty about this one. I had to manually debug the git-committers plugin to figure out I needed to specify a very specific configuration (docs_path). This is related to #156 