### PR TITLE
Fixed a typo in the EC2 Metadata SSRF page description

### DIFF
--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -1,7 +1,7 @@
 ---
 author: Nick Frichette
 title: Steal EC2 Metadata Credentials via SSRF
-description: Old faithful; How to steal IAM Role credentials via the EC2 Metadata service via SSRF.
+description: Old faithful; How to steal IAM Role credentials from the EC2 Metadata service via SSRF.
 ---
 
 !!! Note


### PR DESCRIPTION
This resolves #184