### PR TITLE
Added an author notice at the top of the article template

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,3 +9,10 @@
     <strong>Twitter</strong>
   </a>
 {% endblock %}
+
+{% block content %}
+  {% if page.meta.author %}
+    <p>Article by {{ page.meta.author }}.</p>
+  {% endif %}
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
This has been a consistent problem that I was hoping we could address with the git-authors plugin, however it looks like instead we'll need to put it at the top.