### PR TITLE
Fixed an MKDocs dependency issue

### DIFF
--- a/.github/workflows/deploy_v2.yml
+++ b/.github/workflows/deploy_v2.yml
@@ -21,6 +21,7 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - run: sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+      - run: pip install pillow cairosvg
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-awesome-pages-plugin
       - run: pip install mkdocs-redirects


### PR DESCRIPTION
Not sure when this changed, but there are two additional dependencies which are needed. I've added them to the build for GitHub Actions
```
pip install pillow cairosvg
```