### PR TITLE
Hide the table of contents on pages that don't use it

### DIFF
--- a/content/aws/avoiding-detection/guardduty-pentest.md
+++ b/content/aws/avoiding-detection/guardduty-pentest.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Bypass GuardDuty Pentest Findings
 description: Prevent Kali Linux, ParrotOS, and Pentoo Linux from throwing GuardDuty alerts by modifying the User Agent string.
+hide:
+  - toc
 ---
 
 When making AWS API requests on common penetration testing OS's GuardDuty will detect this and trigger a [PenTest Finding](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#pentest-iam-kalilinux).

--- a/content/aws/avoiding-detection/guardduty-tor-client.md
+++ b/content/aws/avoiding-detection/guardduty-tor-client.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: "Bypass GuardDuty Tor Client Findings"
 description: Connect to the Tor network from an EC2 instance without alerting GuardDuty.
+hide:
+  - toc
 ---
 
 [UnauthorizedAccess:EC2/TorClient](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#unauthorizedaccess-ec2-torclient) is a high severity GuardDuty finding that fires when an EC2 instance is detected making connections to Tor [Guard](https://community.torproject.org/relay/types-of-relays/#Guard%20and%20middle%20relay) or Authority nodes. According to the documentation, "this finding may indicate unauthorized access to your AWS resources with the intent of hiding the attacker's true identity".

--- a/content/aws/avoiding-detection/steal-keys-undetected.md
+++ b/content/aws/avoiding-detection/steal-keys-undetected.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Bypass Credential Exfiltration Detection
 description: When stealing IAM credentials from an EC2 instance you can avoid a GuardDuty detection by using VPC Endpoints.
+hide:
+  - toc
 ---
 
 Link to Tool: [SneakyEndpoints](https://github.com/Frichetten/SneakyEndpoints)

--- a/content/aws/deprecated/stealth_perm_enum.md
+++ b/content/aws/deprecated/stealth_perm_enum.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Enumerate Permissions without Logging to CloudTrail
 description: Leverage a bug in the AWS API to enumerate permissions for a role without logging to CloudTrail and alerting the Blue Team.
+hide:
+  - toc
 ---
 
 Original Research: [Nick Frichette](https://frichetten.com/blog/aws-api-enum-vuln/)  

--- a/content/aws/deprecated/whoami.md
+++ b/content/aws/deprecated/whoami.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Whoami - Get Principal Name From Keys
 description: During an assessment you may find AWS IAM credentials. Use these tactics to identify the principal of the keys.
+hide:
+  - toc
 ---
 
 Original Research: [Spencer Gietzen](https://twitter.com/SpenGietz/status/1283843401008336896)

--- a/content/aws/enumeration/enum_iam_user_role.md
+++ b/content/aws/enumeration/enum_iam_user_role.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Unauthenticated Enumeration of IAM Users and Roles
 description: Leverage cross account behaviors to enumerate IAM users and roles in a different AWS account without authentication.
+hide:
+  - toc
 ---
 
 Original Research: [Daniel Grzelak](https://twitter.com/dagrz) - [Remastered Talk by Scott Piper](https://www.youtube.com/watch?v=8ZXRw4Ry3mQ)  

--- a/content/aws/enumeration/get-account-id-from-keys.md
+++ b/content/aws/enumeration/get-account-id-from-keys.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Get Account ID from AWS Access Keys
 description: During an assessment you may find AWS IAM credentials but not know what account they are associated with. Use this to get the account ID.
+hide:
+  - toc
 ---
 
 While performing an assessment in AWS it is not uncommon to come across access keys and not know what account they are associated with. If your scope is defined by the AWS account ID, this may pose a problem as you'd likely not want to use them if they are out of scope.

--- a/content/aws/exploitation/abusing-container-registry.md
+++ b/content/aws/exploitation/abusing-container-registry.md
@@ -2,6 +2,8 @@
 author: Roi Halawi
 title: Abusing Elastic Container Registry for Lateral Movement
 description: With ECR permissions you can easily distribute a backdoor to production servers, developer's laptops, or CI/CD pipelines and own the environment by gaining privileged permissions.
+hide:
+  - toc
 ---
 
 Original Research: [Roi Halawi](https://medium.com/ironsource-tech-blog/abusing-elastic-container-registry-ecr-to-own-aws-environments-47534ad61729) - [Abusing Elastic Container Registry (ECR) to own AWS environments]
@@ -11,7 +13,7 @@ Original Research: [Roi Halawi](https://medium.com/ironsource-tech-blog/abusing-
 IAM (Identity and Access Management) is a set of consents that attach to identities, or cloud resources, to authorize what they can actually do. This means EC2 resources, and others like it, also have identities that can change the infrastructure itself. 43.9% of organizations have internet-facing workloads containing secrets and credentials, as a result, identity and access management (IAM) has become more critical than ever.
 
 <figure markdown>
-  ![Inbound SG](/images/aws/exploitation/Abusing-Container-Registry/Abusing-Container-Registry.png){ loading=lazy }
+  ![Inbound SG](/images/aws/exploitation/abusing-container-registry/Abusing-Container-Registry.png){ loading=lazy }
 </figure>
 
 This post is designed to show the impact of this attack technique and help security engineers and DevOps/SecOps to detect and understand the risks of ECR and other Container registries.

--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Steal EC2 Metadata Credentials via SSRF
 description: Old faithful; How to steal IAM Role credentials from the EC2 Metadata service via SSRF.
+hide:
+  - toc
 ---
 
 !!! Note

--- a/content/aws/exploitation/lambda-steal-iam-credentials.md
+++ b/content/aws/exploitation/lambda-steal-iam-credentials.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Steal IAM Credentials and Event Data from Lambda
 description: Leverage file read and SSRF vulnerabilities to steam IAM credentials and event data from Lambda.
+hide:
+  - toc
 ---
 
 In Lambda, IAM credentials are passed into the function via environment variables. The benefit for the adversary is that these credentials can be leaked via file read vulnerabilities such as [XML External Entity](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_(XXE)) attacks or SSRF that allows the file protocol. This is because "[everything is a file](https://en.wikipedia.org/wiki/Everything_is_a_file)".

--- a/content/aws/exploitation/local-priv-esc-mod-instance-att.md
+++ b/content/aws/exploitation/local-priv-esc-mod-instance-att.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: "Local Privilege Escalation: User Data"
 description: Escalate privileges on an EC2 instance by modifying the user-data scripts with modify-instance-attribute.
+hide:
+  - toc
 ---
 
 **Required IAM Permission**: [modify-instance-attribute](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-instance-attribute.html)  

--- a/content/aws/exploitation/local-priv-esc-user-data-s3.md
+++ b/content/aws/exploitation/local-priv-esc-user-data-s3.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: "Local Privilege Escalation: User Data 2"
 description: Escalate privileges on an EC2 instance by modifying scripts and packages called by user data.
+hide:
+  - toc
 ---
 
 A common pattern when using EC2 is to define a [user data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) script to be run when an instance is first started or after a reboot. These scripts are typically used to install software, download and set a config, etc. Oftentimes the scripts and packages are pulled from S3 and this introduces an opportunity for a developer/ops person to make a mistake.

--- a/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
@@ -2,6 +2,8 @@
 author: Houston Hopkins
 title: Simple Route53/Cloudfront/S3 Subdomain Takeover
 description: Techniques for taking over subdomains or hostnames that use Cloudfront and/or a DNS record to serve content from Amazon S3.
+hide:
+  - toc
 ---
 
 Research Example: [Patrik Hudak](https://0xpatrik.com/subdomain-takeover-basics/)  

--- a/content/aws/exploitation/route53_modification_privilege_escalation.md
+++ b/content/aws/exploitation/route53_modification_privilege_escalation.md
@@ -2,6 +2,8 @@
 author: Patryk Bogusz
 title: AWS API Call Hijacking via ACM-PCA
 description: By modifying the route53 entries and utilizing the acm-pca private CA one can hijack the calls to AWS API inside the AWS VPC
+hide:
+  - toc
 ---
 
 Original Research: [niebardzo](https://twitter.com/niebardzo2) - [Hijacking AWS API Calls](https://niebardzo.github.io/2022-03-11-aws-hijacking-route53/) 

--- a/content/aws/general-knowledge/connection-tracking.md
+++ b/content/aws/general-knowledge/connection-tracking.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Connection Tracking
 description: Abuse security group connection tracking to maintain persistence even when security group rules are changed.
+hide:
+  - toc
 ---
 
 Security Groups in AWS have an interesting capability known as [Connection Tracking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html). This allows the security groups to track information about the network traffic and allow/deny that traffic based on the Security Group rules.

--- a/content/aws/general-knowledge/iam-key-identifiers.md
+++ b/content/aws/general-knowledge/iam-key-identifiers.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: IAM ID Identifiers
 description: Chart of the IAM ID Prefixes.
+hide:
+  - toc
 ---
 
 [Source](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids)

--- a/content/aws/post_exploitation/get_iam_creds_from_console_session.md
+++ b/content/aws/post_exploitation/get_iam_creds_from_console_session.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: "Get IAM Credentials from a Console Session"
 description: Convert access to the AWS Console into IAM credentials.
+hide:
+  - toc
 ---
 
 Original Research: [Christophe Tafani-Dereeper](https://blog.christophetd.fr/retrieving-aws-security-credentials-from-the-aws-console/?utm_source=pocket_mylist)

--- a/content/aws/post_exploitation/role-chain-juggling.md
+++ b/content/aws/post_exploitation/role-chain-juggling.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Role Chain Juggling
 description: Keep your access by chaining assume-role calls.
+hide:
+  - toc
 ---
 
 Original Research: [Daniel Heinsen](https://twitter.com/hotnops)  

--- a/content/gcp/capture_the_flag/gcp-goat.md
+++ b/content/gcp/capture_the_flag/gcp-goat.md
@@ -2,6 +2,8 @@
 author: Joshua Jebaraj
 title: GCP Goat 
 description: GCP Goat is the Vulnerable application for learning the GCP Security
+hide:
+  - toc
 ---
 
 GCP-Goat is the vulnerable application for learning the Google Cloud Security

--- a/content/gcp/exploitation/gcp-metadata-ssrf.md
+++ b/content/gcp/exploitation/gcp-metadata-ssrf.md
@@ -2,6 +2,8 @@
 author: Chris Moberly
 title: Steal an OAuth Token via SSRF
 description: Using SSRF to steal OAuth Tokens from a GCP hosted VM.
+hide:
+  - toc
 ---
 
 Extracted from the GitLab blog post "[Tutorial on privilege escalation and post exploitation tactics in Google Cloud Platform environments](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/)" by [Chris Moberly](https://about.gitlab.com/company/team/#cmoberly)

--- a/content/gcp/exploitation/gcp_iam_privilege_escalation.md
+++ b/content/gcp/exploitation/gcp_iam_privilege_escalation.md
@@ -2,6 +2,8 @@
 author: Aloïs THÉVENOT
 title: Privilege Escalation in Google Cloud Platform
 description: Privilege escalation techniques for Google Cloud Platform (GCP)
+hide:
+  - toc
 ---
 
 | Permission | Resources |

--- a/content/gcp/general-knowledge/default-account-names.md
+++ b/content/gcp/general-knowledge/default-account-names.md
@@ -4,7 +4,7 @@ title: Default Account Information
 description: Default information on how accounts and service accounts exist in GCP
 ---
 
-# Service Accounts
+## Service Accounts
 
 [Service accounts](https://cloud.google.com/iam/docs/service-accounts) are similar to Azure [Service Principals](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals). They can allow for programmatic access but also abuse. 
 

--- a/content/gcp/general-knowledge/gcp-buckets.md
+++ b/content/gcp/general-knowledge/gcp-buckets.md
@@ -2,6 +2,8 @@
 author: Moses Frost (@mosesrenegade)
 title: Hunting GCP Buckets
 description: How to find valid and invalid GCP Buckets using tools
+hide:
+  - toc
 ---
 
 GCP Buckets are almost 100% identical to AWS S3 Buckets. 

--- a/content/gcp/general-knowledge/security-and-constraints.md
+++ b/content/gcp/general-knowledge/security-and-constraints.md
@@ -7,7 +7,7 @@ description: Security considerations and constraints that are unique to GCP
 
 GCP Resources are typically placed into Projects. Projects are a mix of resource groups in Azure and Accounts in AWS. Projects can be either non-hierarchical or completely hierarchical. An operator can place security constraints on these projects to provide a baseline security policy. There are also Organization-wide policy constraints that apply to every project.
 
-# Examples
+## Examples
 
 From: [Organizational Policy Constraints](https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints)
 

--- a/content/gcp/tools/gcloud.md
+++ b/content/gcp/tools/gcloud.md
@@ -2,6 +2,8 @@
 author: Chris Moberly
 title: Google Cloud CLI
 description: Google Cloud CLI used to create and manage Google Cloud resources. 
+hide:
+  - toc
 ---
 
 Extracted from the GitLab blog post "[Tutorial on privilege escalation and post exploitation tactics in Google Cloud Platform environments](https://about.gitlab.com/blog/2020/02/12/plundering-gcp-escalating-privileges-in-google-cloud-platform/#gcloud)" by [Chris Moberly](https://about.gitlab.com/company/team/#cmoberly)

--- a/content/terraform/terraform_ansi_escape_evasion.md
+++ b/content/terraform/terraform_ansi_escape_evasion.md
@@ -2,6 +2,8 @@
 author: Nick Frichette
 title: Terraform ANSI Escape
 description: Using ANSI Escape Sequences to Hide Malicious Terraform Code
+hide:
+  - toc
 ---
 
 Original Research: [Joern Schneeweisz](https://about.gitlab.com/blog/2022/06/01/terraform-as-part-of-software-supply-chain-part1-modules-and-providers/)


### PR DESCRIPTION
There are a large number of articles that don't have use of the Table of Contents (via Markdown's # feature). As a result, the content of these pages are centered with nothing where the ToC would normally go. This leads to awkard formatting issues and otherwise makes the pages not look as good as they should. I have gone in an applied hide.toc for pages without a table of content, making things look better.