### PR TITLE
Add Mastodon to social links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,8 @@ edit_uri: edit/main/content/
 
 extra:
   social:
+    - icon: fontawesome/brands/mastodon
+      link: https://infosec.exchange/@hackingthecloud
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/Frichette_n
     - icon: fontawesome/brands/linkedin


### PR DESCRIPTION
With the creation of the new Mastodon account, we might as well link to it! https://infosec.exchange/@hackingthecloud 