### PR TITLE
Added clarifying information for authors rights

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ All content submitted to Hacking the Cloud must be written in your own words. Su
 
 __If you are an author and believe your work has been plagiarized on Hacking the Cloud, please submit an [issue](https://github.com/Hacking-the-Cloud/hackingthe.cloud/issues) on GitHub and it will be taken down quickly.__
 
+There is one exception to this policy; If you are the original author of the article or blog post, you are welcome to copy the contents of it and include it here on Hacking the Cloud. This rule is intended to make it easy for authors to contribute their work without having to go through the trouble of editing/changing it. If it is later determined that the submitter is not the original author, the work will be removed.
+
+## Content Removal Policy
+
+If you are a researcher or author and you see that you blog/article has been linked to from Hacking the Cloud and would like it removed, please submit an [issue](https://github.com/Hacking-the-Cloud/hackingthe.cloud/issues) on GitHub and it will be removed. On a case-by-case basis the article will be considered for removal. Please note, however, that if the topic of the article is on a generic topic it is unlikely to be removed. For example, say an article is related to a privilege escalation technique. As a part of that article we may link to an external source as a reference or additional reading. If the author of the external source would like their link removed, it will be. However, the article itself will remain (so long as it is not plagiarized) as an individual cannot claim ownership of a generic technique.
+
 ## Getting Started
 
 Hacking the Cloud uses Material for MkDocs and the Awesome Pages Plugin. To make it easy to setup, there is a Docker file in this repository you can use to get up and running. First, build the docker container.


### PR DESCRIPTION
We recently experienced a situation where our content was plagiarized on another site. In order to be good stewards of the site, we have added clarifying information to our existing plagiarism policy. In particular:

1. If an author would like a link to their page/website removed they have the right to do so
2. Plagiarism of content submitted to Hacking the Cloud is not tolerated and is subject to removal.
3. There is an exception to the plagiarism policy if the original author of the content submits it. This is intended to make it easier for authors to contribute without having to change large chunks of their work. 