### PR TITLE
Changed author tag to author_name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ After creating the file, please put the following at the top and fill it out.
 
 ```
 ---
-author: <Your Name>
+author_name: <Your Name>
 title: <Page Title>
 description: <A description of the page>
 ---

--- a/content/aws/avoiding-detection/guardduty-pentest.md
+++ b/content/aws/avoiding-detection/guardduty-pentest.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Bypass GuardDuty Pentest Findings
 description: Prevent Kali Linux, ParrotOS, and Pentoo Linux from throwing GuardDuty alerts by modifying the User Agent string.
 hide:

--- a/content/aws/avoiding-detection/guardduty-tor-client.md
+++ b/content/aws/avoiding-detection/guardduty-tor-client.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Bypass GuardDuty Tor Client Findings"
 description: Connect to the Tor network from an EC2 instance without alerting GuardDuty.
 hide:

--- a/content/aws/avoiding-detection/modify-guardduty-config.md
+++ b/content/aws/avoiding-detection/modify-guardduty-config.md
@@ -1,5 +1,5 @@
 ---
-author: Ben Leembruggen
+author_name: Ben Leembruggen
 title: Modify GuardDuty Configuration
 description: Modify existing GuardDuty configurations in the target account to hinder alerting and remediation capabilities.
 ---

--- a/content/aws/avoiding-detection/steal-keys-undetected.md
+++ b/content/aws/avoiding-detection/steal-keys-undetected.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Bypass Credential Exfiltration Detection
 description: When stealing IAM credentials from an EC2 instance you can avoid a GuardDuty detection by using VPC Endpoints.
 hide:

--- a/content/aws/capture_the_flag/cicdont.md
+++ b/content/aws/capture_the_flag/cicdont.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: CI/CDon't
 description: An AWS/GitLab CICD themed CTF.
 ---

--- a/content/aws/deprecated/stealth_perm_enum.md
+++ b/content/aws/deprecated/stealth_perm_enum.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Enumerate Permissions without Logging to CloudTrail
 description: Leverage a bug in the AWS API to enumerate permissions for a role without logging to CloudTrail and alerting the Blue Team.
 hide:

--- a/content/aws/deprecated/whoami.md
+++ b/content/aws/deprecated/whoami.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Whoami - Get Principal Name From Keys
 description: During an assessment you may find AWS IAM credentials. Use these tactics to identify the principal of the keys.
 hide:

--- a/content/aws/enumeration/account_id_from_ec2.md
+++ b/content/aws/enumeration/account_id_from_ec2.md
@@ -1,5 +1,5 @@
 ---
-author: Phil Massyn
+author_name: Phil Massyn
 title: Enumerate AWS Account ID from an EC2 Instance
 description: With access to an ec2 instance, you will be able to identify the AWS account it runs in.
 ---

--- a/content/aws/enumeration/account_id_from_s3_bucket.md
+++ b/content/aws/enumeration/account_id_from_s3_bucket.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Enumerate AWS Account ID from a Public S3 Bucket
 description: Knowing only the name of a public S3 bucket, you can ascertain the account ID it resides in.
 ---

--- a/content/aws/enumeration/brute_force_iam_permissions.md
+++ b/content/aws/enumeration/brute_force_iam_permissions.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Brute Force IAM Permissions
 description: Brute force the IAM permissions of a user or role to see what you have access to.
 ---

--- a/content/aws/enumeration/enum_iam_user_role.md
+++ b/content/aws/enumeration/enum_iam_user_role.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Unauthenticated Enumeration of IAM Users and Roles
 description: Leverage cross account behaviors to enumerate IAM users and roles in a different AWS account without authentication.
 hide:

--- a/content/aws/enumeration/get-account-id-from-keys.md
+++ b/content/aws/enumeration/get-account-id-from-keys.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Get Account ID from AWS Access Keys
 description: During an assessment you may find AWS IAM credentials but not know what account they are associated with. Use this to get the account ID.
 hide:

--- a/content/aws/enumeration/whoami.md
+++ b/content/aws/enumeration/whoami.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Whoami - Get Principal Name From Keys
 description: During an assessment you may find AWS IAM credentials. Use these tactics to identify the principal of the keys.
 ---

--- a/content/aws/exploitation/Misconfigured_Resource-Based_Policies/index.md
+++ b/content/aws/exploitation/Misconfigured_Resource-Based_Policies/index.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Misconfigured Resource-Based Policies
 description: Common misconfigurations of resource-based policies and how they can be abused.
 ---

--- a/content/aws/exploitation/Misconfigured_Resource-Based_Policies/misconfigured_ecr_resource_policy.md
+++ b/content/aws/exploitation/Misconfigured_Resource-Based_Policies/misconfigured_ecr_resource_policy.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Abusing Misconfigured ECR Resource Policies
 description: How to take advantage of misconfigured AWS ECR private repositories.
 ---

--- a/content/aws/exploitation/abusing-container-registry.md
+++ b/content/aws/exploitation/abusing-container-registry.md
@@ -1,5 +1,5 @@
 ---
-author: Roi Lavie
+author_name: Roi Lavie
 title: Abusing Elastic Container Registry for Lateral Movement
 description: With ECR permissions you can easily distribute a backdoor to production servers, developer's laptops, or CI/CD pipelines and own the environment by gaining privileged permissions.
 hide:

--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Steal EC2 Metadata Credentials via SSRF
 description: Old faithful; How to steal IAM Role credentials from the EC2 Metadata service via SSRF.
 hide:

--- a/content/aws/exploitation/iam_privilege_escalation.md
+++ b/content/aws/exploitation/iam_privilege_escalation.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: AWS IAM Privilege Escalation Techniques
 description: Common techniques that can be leveraged to escalate privileges in an AWS account.
 ---

--- a/content/aws/exploitation/lambda-steal-iam-credentials.md
+++ b/content/aws/exploitation/lambda-steal-iam-credentials.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Steal IAM Credentials and Event Data from Lambda
 description: Leverage file read and SSRF vulnerabilities to steam IAM credentials and event data from Lambda.
 hide:

--- a/content/aws/exploitation/local-priv-esc-mod-instance-att.md
+++ b/content/aws/exploitation/local-priv-esc-mod-instance-att.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Local Privilege Escalation: User Data"
 description: Escalate privileges on an EC2 instance by modifying the user-data scripts with modify-instance-attribute.
 hide:

--- a/content/aws/exploitation/local-priv-esc-user-data-s3.md
+++ b/content/aws/exploitation/local-priv-esc-user-data-s3.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Local Privilege Escalation: User Data 2"
 description: Escalate privileges on an EC2 instance by modifying scripts and packages called by user data.
 hide:

--- a/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
@@ -1,5 +1,5 @@
 ---
-author: Houston Hopkins
+author_name: Houston Hopkins
 title: Simple Route53/Cloudfront/S3 Subdomain Takeover
 description: Techniques for taking over subdomains or hostnames that use Cloudfront and/or a DNS record to serve content from Amazon S3.
 hide:

--- a/content/aws/exploitation/route53_modification_privilege_escalation.md
+++ b/content/aws/exploitation/route53_modification_privilege_escalation.md
@@ -1,5 +1,5 @@
 ---
-author: Patryk Bogusz
+author_name: Patryk Bogusz
 title: AWS API Call Hijacking via ACM-PCA
 description: By modifying the route53 entries and utilizing the acm-pca private CA one can hijack the calls to AWS API inside the AWS VPC
 hide:

--- a/content/aws/general-knowledge/aws_organizations_defaults.md
+++ b/content/aws/general-knowledge/aws_organizations_defaults.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: AWS Organizations Defaults
 description: AWS Organizations is a common service to run into in AWS environments. It's default behavior can make it a target for attackers.
 ---

--- a/content/aws/general-knowledge/connection-tracking.md
+++ b/content/aws/general-knowledge/connection-tracking.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Connection Tracking
 description: Abuse security group connection tracking to maintain persistence even when security group rules are changed.
 hide:

--- a/content/aws/general-knowledge/create_a_console_session_from_iam_credentials.md
+++ b/content/aws/general-knowledge/create_a_console_session_from_iam_credentials.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Create a Console Session from IAM Credentials
 description: "How to use IAM credentials to create an AWS Console session."
 ---

--- a/content/aws/general-knowledge/iam-key-identifiers.md
+++ b/content/aws/general-knowledge/iam-key-identifiers.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: IAM ID Identifiers
 description: Chart of the IAM ID Prefixes.
 hide:

--- a/content/aws/general-knowledge/intro_metadata_service.md
+++ b/content/aws/general-knowledge/intro_metadata_service.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Introduction to the Instance Metadata Service
 description: An introduction to the Instance Metadata Service and how to access it.
 ---

--- a/content/aws/general-knowledge/introduction_user_data.md
+++ b/content/aws/general-knowledge/introduction_user_data.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Introduction to User Data
 description: An introduction to EC2 User Data and how to access it.
 ---

--- a/content/aws/general-knowledge/using_stolen_iam_credentials.md
+++ b/content/aws/general-knowledge/using_stolen_iam_credentials.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Using Stolen IAM Credentials
 description: How to work with stolen IAM credentials and things to consider.
 ---

--- a/content/aws/post_exploitation/get_iam_creds_from_console_session.md
+++ b/content/aws/post_exploitation/get_iam_creds_from_console_session.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Get IAM Credentials from a Console Session"
 description: Convert access to the AWS Console into IAM credentials.
 hide:

--- a/content/aws/post_exploitation/intercept_ssm_communications.md
+++ b/content/aws/post_exploitation/intercept_ssm_communications.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Intercept SSM Communications
 description: With access to an EC2 instance you can intercept, modify, and spoof SSM communications.
 ---

--- a/content/aws/post_exploitation/lambda_persistence.md
+++ b/content/aws/post_exploitation/lambda_persistence.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Lambda Persistence
 description: How to establish persistence on a Lambda function after getting remote code execution.
 ---

--- a/content/aws/post_exploitation/role-chain-juggling.md
+++ b/content/aws/post_exploitation/role-chain-juggling.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Role Chain Juggling
 description: Keep your access by chaining assume-role calls.
 hide:

--- a/content/aws/post_exploitation/run_shell_commands_on_ec2.md
+++ b/content/aws/post_exploitation/run_shell_commands_on_ec2.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Run Shell Commands on EC2 with Send Command or Session Manager"
 description: Leverage privileged access in an AWS account to run arbitrary commands on an EC2 instance.
 ---

--- a/content/aws/post_exploitation/s3_acl_persistence.md
+++ b/content/aws/post_exploitation/s3_acl_persistence.md
@@ -1,5 +1,5 @@
 ---
-author: Wes Ladd
+author_name: Wes Ladd
 title: S3 File ACL Persistence
 description: Maintain access to S3 resources by configuring Access Control Lists associated with S3 Buckets or Objects.
 ---

--- a/content/aws/post_exploitation/user_data_script_persistence.md
+++ b/content/aws/post_exploitation/user_data_script_persistence.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: User Data Script Persistence
 description: Maintain access to an EC2 instance and it's IAM role via user data scripts.
 ---

--- a/content/azure/abusing-managed-identities.md
+++ b/content/azure/abusing-managed-identities.md
@@ -1,5 +1,5 @@
 ---
-author: andrei8055
+author_name: andrei8055
 title: Abusing Managed Identities
 description: Abusing Managed Identities 
 ---

--- a/content/azure/anonymous-blob-access.md
+++ b/content/azure/anonymous-blob-access.md
@@ -1,5 +1,5 @@
 ---
-author: andrei8055
+author_name: andrei8055
 title: Anonymous Blob Access
 description: Finding and accessing files stored in Azure Storage Accounts without authentication.
 ---

--- a/content/azure/soft-deleted-blobs.md
+++ b/content/azure/soft-deleted-blobs.md
@@ -1,5 +1,5 @@
 ---
-author: andrei8055
+author_name: andrei8055
 title: Soft Deleted Blobs
 description: Recovering and accessing files in private Storage Accounts that have been deleted.
 ---

--- a/content/gcp/capture_the_flag/gcp-goat.md
+++ b/content/gcp/capture_the_flag/gcp-goat.md
@@ -1,5 +1,5 @@
 ---
-author: Joshua Jebaraj
+author_name: Joshua Jebaraj
 title: GCP Goat 
 description: GCP Goat is the Vulnerable application for learning the GCP Security
 hide:

--- a/content/gcp/capture_the_flag/thunder_ctf.md
+++ b/content/gcp/capture_the_flag/thunder_ctf.md
@@ -1,5 +1,5 @@
 ---
-author: Aloïs THÉVENOT
+author_name: Aloïs THÉVENOT
 title: Thunder CTF
 description: GCP themed CTF
 ---

--- a/content/gcp/enumeration/enumerate_service_account_permissions.md
+++ b/content/gcp/enumeration/enumerate_service_account_permissions.md
@@ -1,5 +1,5 @@
 ---
-author: Aloïs THÉVENOT
+author_name: Aloïs THÉVENOT
 title: Enumerate Service Account Permissions
 description: Brute force the permissions of a service account to see what you have access to.
 ---

--- a/content/gcp/exploitation/gcp-metadata-ssrf.md
+++ b/content/gcp/exploitation/gcp-metadata-ssrf.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Steal an OAuth Token via SSRF
 description: Using SSRF to steal OAuth Tokens from a GCP hosted VM.
 hide:

--- a/content/gcp/exploitation/gcp-priv-esc.md
+++ b/content/gcp/exploitation/gcp-priv-esc.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: GCP Privilege Escalation
 description: Common privilege escalation techniques in GCP.
 ---

--- a/content/gcp/exploitation/gcp_iam_privilege_escalation.md
+++ b/content/gcp/exploitation/gcp_iam_privilege_escalation.md
@@ -1,5 +1,5 @@
 ---
-author: Aloïs THÉVENOT
+author_name: Aloïs THÉVENOT
 title: Privilege Escalation in Google Cloud Platform
 description: Privilege escalation techniques for Google Cloud Platform (GCP)
 hide:

--- a/content/gcp/exploitation/local-priv-esc-metadata.md
+++ b/content/gcp/exploitation/local-priv-esc-metadata.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: "Local Privilege Escalation: Modifying the Metadata"
 description: Escalating privileges on a VM via instance metadata.
 ---

--- a/content/gcp/general-knowledge/client-credential-search-order.md
+++ b/content/gcp/general-knowledge/client-credential-search-order.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Client Credential Search Order
 description: The order by which GCP client libraries search for credentials.
 ---

--- a/content/gcp/general-knowledge/default-account-names.md
+++ b/content/gcp/general-knowledge/default-account-names.md
@@ -1,5 +1,5 @@
 ---
-author: Moses Frost (@mosesrenegade)
+author_name: Moses Frost (@mosesrenegade)
 title: Default Account Information
 description: Default information on how accounts and service accounts exist in GCP
 ---

--- a/content/gcp/general-knowledge/gcp-buckets.md
+++ b/content/gcp/general-knowledge/gcp-buckets.md
@@ -1,5 +1,5 @@
 ---
-author: Moses Frost (@mosesrenegade)
+author_name: Moses Frost (@mosesrenegade)
 title: Hunting GCP Buckets
 description: How to find valid and invalid GCP Buckets using tools
 hide:

--- a/content/gcp/general-knowledge/metadata_in_google_cloud_instances.md
+++ b/content/gcp/general-knowledge/metadata_in_google_cloud_instances.md
@@ -1,5 +1,5 @@
 ---
-author: Jan Slezak
+author_name: Jan Slezak
 title: Metadata in Google Cloud Instances
 description: Information about the data an attacker can access via GCP's API endpoints
 hide:

--- a/content/gcp/general-knowledge/security-and-constraints.md
+++ b/content/gcp/general-knowledge/security-and-constraints.md
@@ -1,5 +1,5 @@
 ---
-author: Moses Frost (@mosesrenegade)
+author_name: Moses Frost (@mosesrenegade)
 title: Security and Constraints
 description: Security considerations and constraints that are unique to GCP
 ---

--- a/content/gcp/general-knowledge/security-concepts.md
+++ b/content/gcp/general-knowledge/security-concepts.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Security Concepts
 description: Common security concepts in GCP.
 ---

--- a/content/gcp/post_exploitation/lateral-movement.md
+++ b/content/gcp/post_exploitation/lateral-movement.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Lateral Movement
 description: Common lateral movement techniques in GCP.
 ---

--- a/content/gcp/post_exploitation/treasure_hunting.md
+++ b/content/gcp/post_exploitation/treasure_hunting.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Treasure hunting
 description: The following sections detail tactics to view and exfiltrate data from various Google services..
 ---

--- a/content/gcp/tools/gcloud.md
+++ b/content/gcp/tools/gcloud.md
@@ -1,5 +1,5 @@
 ---
-author: Chris Moberly
+author_name: Chris Moberly
 title: Google Cloud CLI
 description: Google Cloud CLI used to create and manage Google Cloud resources. 
 hide:

--- a/content/terraform/terraform_ansi_escape_evasion.md
+++ b/content/terraform/terraform_ansi_escape_evasion.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: Terraform ANSI Escape
 description: Using ANSI Escape Sequences to Hide Malicious Terraform Code
 hide:

--- a/content/terraform/terraform_enterprise_metadata_service.md
+++ b/content/terraform/terraform_enterprise_metadata_service.md
@@ -1,5 +1,5 @@
 ---
-author: Nick Frichette
+author_name: Nick Frichette
 title: "Terraform Enterprise: Attack the Metadata Service"
 description: Leverage a default configuration in Terraform Enterprise to steal credentials from the Metadata Service
 ---

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block content %}
-  {% if page.meta.author %}
-    <p>Article by {{ page.meta.author }}.</p>
+  {% if page.meta.author_name %}
+    <p>Article by {{ page.meta.author_name }}.</p>
   {% endif %}
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This PR changes a bug in the plugin we use to generate RSS feeds. Long story short, the plugin extracts the `author` field from the page metadata. However as mentioned [here](https://github.com/Guts/mkdocs-rss-plugin/issues/34), the RSS spec expects this to include an email address. This is sub-optimal because we don't want to force people to provide that. Additionally there is no way to turn this off in the plugin.

To get around this I've changed the `author` field to `author_name`. To facilitate this, I've modified our contributing docs to ensure there is a new template, modified our `overrides` to expect this new name, and gone through all the pages in the site and updated this. 

While this is an inelegant solution, it solves the problem quickly and ensures we will have RSS support, which is a win :)