### PR TITLE
Add pep517 flag to install mkdocs-glightbox

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -19,5 +19,5 @@ jobs:
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-rss-plugin
-      - run: pip install mkdocs-glightbox
+      - run: pip install --use-pep517 mkdocs-glightbox
       - run: mkdocs build

--- a/.github/workflows/deploy_v2.yml
+++ b/.github/workflows/deploy_v2.yml
@@ -28,6 +28,6 @@ jobs:
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-rss-plugin
-      - run: pip install mkdocs-glightbox
+      - run: pip install --use-pep517 mkdocs-glightbox
       - run: pip install git+https://${{ secrets.GH_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
       - run: mkdocs gh-deploy --force --config-file mkdocs.insiders.yml


### PR DESCRIPTION
Seems there is a minor issue with using [mkdocs-glightbox](https://blueswen.github.io/mkdocs-glightbox/) in GitHub actions related to [this](https://github.com/blueswen/mkdocs-glightbox/issues/12). May require future testing but our initial deploy did not work. I'm adding this flag hopefully as a quick fix. 