### PR TITLE
Demoing info cards at the top of an article

### DIFF
--- a/content/aws/enumeration/account_id_from_s3_bucket.md
+++ b/content/aws/enumeration/account_id_from_s3_bucket.md
@@ -4,9 +4,24 @@ title: Enumerate AWS Account ID from a Public S3 Bucket
 description: Knowing only the name of a public S3 bucket, you can ascertain the account ID it resides in.
 ---
 
-Discovered by [Ben Bridts](https://twitter.com/benbridts)  
-Original Research: [link](https://www.cloudar.be/awsblog/finding-the-accountid-of-any-public-s3-bucket/)  
-Link to Tool: [s3-account-search](https://github.com/WeAreCloudar/s3-account-search)
+<div class="grid cards" markdown>
+
+-   :material-account:{ .lg .middle } __Original Research__
+
+    ---
+
+    <aside style="display:flex">
+    <p><a href="https://cloudar.be/awsblog/finding-the-account-id-of-any-public-s3-bucket/">Finding the Account ID of any public S3 bucket</a> by <a href="https://twitter.com/benbridts">Ben Bridts</a></p>
+    <p><img src="https://pbs.twimg.com/profile_images/1153675351119343616/YZ1At6W7_400x400.jpg" style="width:44px;height:44px;margin:5px;border-radius:100%;max-width:unset"></img></p>
+    </aside>
+
+-   :material-tools:{ .lg .middle } __Tools mentioned in this article__
+
+    ---
+
+    [s3-account-search](https://github.com/WeAreCloudar/s3-account-search): A tool to find the account ID an S3 bucket belongs to.
+
+</div>
 
 !!! Note
     The documentation and GitHub repository refer to this tool as `s3-account-search`, however when it is installed using [pip](https://pip.pypa.io/en/stable/), it is named `s3-account-finder`. Because of this, all the examples below will use the `s3-account-finder` name.

--- a/content/aws/enumeration/brute_force_iam_permissions.md
+++ b/content/aws/enumeration/brute_force_iam_permissions.md
@@ -4,7 +4,21 @@ title: Brute Force IAM Permissions
 description: Brute force the IAM permissions of a user or role to see what you have access to.
 ---
 
-Link to Tool: [GitHub](https://github.com/andresriancho/enumerate-iam)
+<div class="grid cards" markdown>
+
+-   :material-alert-decagram:{ .lg .middle } __Technique seen in the wild__
+
+    ---
+
+    Reference: [Compromised Cloud Compute Credentials: Case Studies From the Wild](https://unit42.paloaltonetworks.com/compromised-cloud-compute-credentials/#post-125981-_lfnmqg2a6dto)
+
+-   :material-tools:{ .lg .middle } __Tools mentioned in this article__
+
+    ---
+
+    [enumerate-iam](https://github.com/andresriancho/enumerate-iam): Enumerate the permissions associated with an AWS credential set.
+
+</div>
 
 When attacking AWS you may compromise credentials for an IAM user or role. This can be an excellent step to gain access to other resources, however it presents a problem for us; How do we know what permissions we have access to? While we may have context clues based on the name of the role/user or based on where we found them, this is hardly exhaustive or thorough. 
 

--- a/content/aws/general-knowledge/create_a_console_session_from_iam_credentials.md
+++ b/content/aws/general-knowledge/create_a_console_session_from_iam_credentials.md
@@ -4,8 +4,17 @@ title: Create a Console Session from IAM Credentials
 description: "How to use IAM credentials to create an AWS Console session."
 ---
 
-Link to Tool: [aws-vault](https://github.com/99designs/aws-vault)  
-Alternative Tool: [leapp](https://github.com/Noovolari/leapp)
+<div class="grid cards" markdown>
+
+-   :material-tools:{ .lg .middle } __Tools mentioned in this article__
+
+    ---
+
+    [aws-vault](https://github.com/99designs/aws-vault): A vault for securely storing and accessing AWS credentials in development environments.
+
+    [leapp](https://github.com/Noovolari/leapp): Leapp is the DevTool to access your cloud.
+
+</div>
 
 When performing an AWS assessment you will likely encounter IAM credentials. These credentials can be used with the [AWS CLI](/aws/general-knowledge/using_stolen_iam_credentials/#working-with-the-keys) or other tooling to query the AWS API. 
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is intended for local testing and requires a subscription to 
+# Material for MkDocs to work. If you'd like to contribute to Hacking the Cloud
+# and need to setup a local env, you can use the normal "Dockerfile" in this repo.
+# Thank you!
+FROM ubuntu
+
+ARG GH_TOKEN
+
+WORKDIR /docs
+
+RUN apt update -y
+RUN apt install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev python3-pip python3 git
+RUN pip install pillow cairosvg
+RUN pip install mkdocs-minify-plugin
+RUN pip install mkdocs-awesome-pages-plugin
+RUN pip install mkdocs-redirects
+RUN pip install mkdocs-git-revision-date-localized-plugin
+RUN pip install mkdocs-git-committers-plugin-2
+RUN pip install mkdocs-rss-plugin
+RUN pip install --use-pep517 mkdocs-glightbox
+RUN pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git


### PR DESCRIPTION
Testing out the concept of "info cards" at the top of articles. Currently we have individual links at the top which work, but are not visually appealing. With cards we can make this look better and include extras such as researcher pictures and tool descriptions. This commit is a proof of concept to see what others think.