### PR TITLE
Fixed the missing page edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
     # - navigation.instant  Add this at a later date
     - navigation.tabs
     - navigation.indexes
+    - content.action.edit
   palette:
     - scheme: slate
       primary: red


### PR DESCRIPTION
For some reason the page edit button is missing. Looking at the [documentation](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/?h=edit#edit-this-page), it appears as if there was a recent change in `9.0.0`. Setting this flag to fix.