### PR TITLE
Added technique seen in the wild flag to create console session

### DIFF
--- a/content/aws/post_exploitation/create_a_console_session_from_iam_credentials.md
+++ b/content/aws/post_exploitation/create_a_console_session_from_iam_credentials.md
@@ -6,6 +6,12 @@ description: "How to use IAM credentials to create an AWS Console session."
 
 <div class="grid cards" markdown>
 
+-   :material-alert-decagram:{ .lg .middle } __Technique seen in the wild__
+
+    ---
+
+    Reference: [Not a SIMulation: CrowdStrike Investigations Reveal Intrusion Campaign Targeting Telco and BPO Companies](https://www.crowdstrike.com/blog/analysis-of-intrusion-campaign-targeting-telecom-and-bpo-companies/)
+
 -   :material-tools:{ .lg .middle } __Tools mentioned in this article__
 
     ---
@@ -16,6 +22,9 @@ description: "How to use IAM credentials to create an AWS Console session."
 
 </div>
 
+!!! Note
+    Previous versions of this article made use of a tool called [aws_consoler](https://github.com/NetSPI/aws_consoler). Because the tool is no longer maintained it is not recommended. Instead use [aws-vault](https://github.com/99designs/aws-vault) or something similar.
+
 When performing an AWS assessment you will likely encounter IAM credentials. These credentials can be used with the [AWS CLI](/aws/general-knowledge/using_stolen_iam_credentials/#working-with-the-keys) or other tooling to query the AWS API. 
 
 While this can be useful, sometimes you just can't beat clicking around the console. If you have IAM credentials, there is a way that you can spawn an AWS Console session using a tool such as [aws-vault](https://github.com/99designs/aws-vault). This can make certain actions much easier rather than trying to remember the specific flag name for the AWS CLI.
@@ -24,7 +33,7 @@ While this can be useful, sometimes you just can't beat clicking around the cons
     If you are using temporary IAM credentials (ASIA...), for example, from an EC2 instance, you do not need to have any special IAM permissions to do this. If you are using long-term credentials (AKIA...), you need to have either [sts:GetFederationToken](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-federation-token.html) or [sts:AssumeRole](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html) permissions. This is to generate the temporary credentials you will need.
 
 !!! Tip
-    If you are attempting to avoid detection, this technique is **not** recommended. Aside from the suspicious `ConsoleLogin` CloudTrail log, and the odd user-agent (Why is the IAM role associated with the CI/CD server using a Firefox user-agent string?), you will also generate a ton of CloudTrail logs.
+    If you are attempting to avoid detection, this technique is **not** recommended. Aside from the suspicious `ConsoleLogin` CloudTrail log, and the odd user-agent (Ex: Why is the IAM role associated with the CI/CD server using a Firefox user-agent string?), you will also generate a ton of CloudTrail logs.
 
 To start, [export the relevant environment variables](/aws/general-knowledge/using_stolen_iam_credentials/#working-with-the-keys) for the IAM credentials you have. Next, [install aws-vault](https://github.com/99designs/aws-vault#installing).
 


### PR DESCRIPTION
As noted in [this](https://www.crowdstrike.com/blog/analysis-of-intrusion-campaign-targeting-telecom-and-bpo-companies/) article from Crowdstrike, [aws_consoler](https://github.com/NetSPI/aws_consoler) was used in the wild. Because of this, I am adding the `Technique seen in the wild` card to the related article.