### PR TITLE
Add Technique Seen in the Wild card for Steal IAM Credentials and Event Data from Lambda

### DIFF
--- a/content/aws/exploitation/lambda-steal-iam-credentials.md
+++ b/content/aws/exploitation/lambda-steal-iam-credentials.md
@@ -8,6 +8,16 @@ hide:
 
 # Steal IAM Credentials and Event Data from Lambda
 
+<div class="grid cards" markdown>
+
+-   :material-alert-decagram:{ .lg .middle } __Technique seen in the wild__
+
+    ---
+
+    Reference: [Compromised Cloud Compute Credentials: Case Studies From the Wild](https://unit42.paloaltonetworks.com/compromised-cloud-compute-credentials/#post-125981-_kdq0vw6banab)
+
+</div>
+
 In Lambda, IAM credentials are passed into the function via environment variables. The benefit for the adversary is that these credentials can be leaked via file read vulnerabilities such as [XML External Entity](https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A4-XML_External_Entities_(XXE)) attacks or SSRF that allows the file protocol. This is because "[everything is a file](https://en.wikipedia.org/wiki/Everything_is_a_file)".
 
 IAM credentials can be accessed via reading `/proc/self/environ`.


### PR DESCRIPTION
Based on a report for [Palo Alto](https://unit42.paloaltonetworks.com/compromised-cloud-compute-credentials/#post-125981-_kdq0vw6banab) I have added a Technique Seen in the Wild card for the Steal IAM Credentials and Event Data from Lambda article. 