### PR TITLE
Updated references with grid cards for dangling subdomain article

### DIFF
--- a/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_ cloudfront_or_dns_takeover_via_s3.md
@@ -8,10 +8,23 @@ hide:
 
 # Simple Route53/Cloudfront/S3 Subdomain Takeover
 
-Research Example: [Patrik Hudak](https://0xpatrik.com/subdomain-takeover-basics/)  
-Link to Tool: [dwatch](https://github.com/houey/dwatch)  
-Link to Tool: [ctfr](https://github.com/UnaPibaGeek/ctfr)  
-Link to Tool: [Amass](https://github.com/OWASP/Amass)  
+<div class="grid cards" markdown>
+
+-   :material-menu_book:{ .lg .middle } __Additional Resources__
+
+    ---
+
+    [Discover Dangling Domains that point to your cloud assets to prevent subdomain takeover](https://blog.lightspin.io/discover-dangling-domains-that-point-to-your-cloud-assets-to-prevent-subdomain-takeover)
+
+-   :material-tools:{ .lg .middle } __Tools mentioned in this article__
+
+    ---
+
+    [dwatch](https://github.com/houey/dwatch):  Fork and stripped down version of a now defunct DomainWatch script from ebelties.
+    [ctfr](https://github.com/UnaPibaGeek/ctfr): Abusing Certificate Transparency logs for getting HTTPS websites subdomains. 
+    [Amass](https://github.com/OWASP/Amass): In-depth attack surface mapping and asset discovery.
+
+</div>
 
 Utilizing various enumeration techniques for recon and enumeration, an attacker can discover orphaned Cloudfront distributions and/or DNS Records that are attempting to serve content from an S3 bucket that no longer exists. There are numerous tools to do this, but I have been using dwatch combined with CTFR. 
 


### PR DESCRIPTION
After reading [this](https://blog.lightspin.io/discover-dangling-domains-that-point-to-your-cloud-assets-to-prevent-subdomain-takeover) article from Lightspin, I wanted to add it as a reference to the dangling subdomain article. This also served as an excellent opportunity to add grid cards.