### PR TITLE
Removed two unneeded summary headers in articles

### DIFF
--- a/content/aws/exploitation/cognito_identity_pool_excessive_privileges.md
+++ b/content/aws/exploitation/cognito_identity_pool_excessive_privileges.md
@@ -4,7 +4,7 @@ title: Abusing Overpermissioned AWS Cognito Identity Pools
 description: How to take advantage of misconfigured Amazon Cognito Identity Pools.
 ---
 # Overpermissioned AWS Cognito Identity Pools
-## Summary
+
 A significant security flaw in applications using AWS Cognito for identity management can occur when identity pools are given excessive privileges. Excessive privileges in an Identity Pool mean that the identities (users) associated with that pool can perform actions beyond what is necessary for their role in the application.
 
 If an attacker successfully authenticates with the AWS Cognito service (such as through the [unintended self-signup](./cognito_user_self_signup.md), and the corresponding identity pool has excessive privileges, the attacker can potentially perform actions that should be restricted. This might include accessing sensitive data, manipulating services, and, in some cases, privilege escalation.

--- a/content/aws/exploitation/cognito_user_self_signup.md
+++ b/content/aws/exploitation/cognito_user_self_signup.md
@@ -4,7 +4,7 @@ title: Abusing Unintended Self-Signup in AWS Cognito
 description: How to take advantage of misconfigured Amazon Cognito User Pools.
 ---
 # Unintended Self-Signup in AWS Cognito
-## Summary
+
 A common security flaw in SaaS applications that use Amazon Cognito as the IAM authn/authz source is allowing unintended/unauthorized account creation. Many times, such applications are intended to only allow Administrators to sign up users. 
 
 However, applications using Cognito are frequently not explicitly configured to require Administrator only sign-up. Just because a sign-up page or button is not present in the application, doesn't mean that an attacker can't sign up for an account. __If "Admin Only" signup is not enabled__ in the Cognito User Pool and an attacker can identify the Cognito User Pool Client ID and required sign-up parameters, they can sign up for an account using the AWS CLI.


### PR DESCRIPTION
There were two random `Summary` headers on some articles that weren't needed. I removed them :)