### PR TITLE
Improved the EC2 SSRF article

### DIFF
--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -9,32 +9,41 @@ hide:
 # Steal EC2 Metadata Credentials via SSRF
 
 !!! Note
-    This is a common and well known attack in AWS environments. [Mandiant](https://www.mandiant.com/) has identified [attackers performing automated scanning of vulnerabilities](https://www.mandiant.com/resources/cloud-metadata-abuse-unc2903) to harvest IAM credentials from publicly-facing web applications. To mitigate the risks of this for your organization, it would be beneficial to enforce [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) for all EC2 instances which has [additional security benefits](https://hackingthe.cloud/aws/general-knowledge/intro_metadata_service/#the-security-benefits-of-imdsv2). IMDSv2 would significantly reduce the risk of an adversary stealing IAM credentials via SSRF.
+    This is a common and well known attack in AWS environments. [Mandiant](https://www.mandiant.com/) has identified [attackers performing automated scanning of vulnerabilities](https://www.mandiant.com/resources/cloud-metadata-abuse-unc2903) to harvest IAM credentials from publicly-facing web applications. To mitigate the risks of this for your organization, it would be beneficial to enforce [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) for all EC2 instances which has [additional security benefits](https://hackingthe.cloud/aws/general-knowledge/intro_metadata_service/#the-security-benefits-of-imdsv2). IMDSv2 would significantly reduce the risk of an adversary stealing IAM credentials via SSRF or XXE attacks.
 
-One of the most commonly taught tactics in AWS exploitation is the use of Server Side Request Forgery (SSRF) to access the EC2 metadata service.
+One of the most common techniques in AWS exploitation is abusing the [Instance Metadata Service](https://hackingthe.cloud/aws/general-knowledge/intro_metadata_service/) (IMDS) associated with a target EC2 instance.
 
-Most EC2 Instances have access to the metadata service at 169.254.169.254. This contains useful information about the instance such as its IP address, the name of the security group, etc. On EC2 instances that have an IAM role attached the metadata service will also contain IAM credentials to authenticate as this role. Depending on what version of IMDS is in place, and what capabilities the SSRF has we can steal those credentials.
+Most EC2 instances can access their IMDS at 169.254.169.254. This service is only accessible from the specific EC2 instance it is associated with. The instance metadata service contains useful information about the instance, such as its IP address, its instance type, the name of the security groups associated with it, etc.
 
-It is also worth noting that shell access to the EC2 instance would also allow an adversary to gather these credentials.
+If an EC2 instance has an IAM role attached to it, [IAM credentials](https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/) associated with that role can be retrieved from the metadata service. Because of this, attackers will frequently target the IMDS to steal those credentials.
 
-In this example there is a web server running on port 80 of the EC2 instance. This web server has a simple SSRF vulnerability, allowing us to make GET requests to arbitrary addresses. We can leverage this to make a request to `http://169.254.169.254`.
+## Stealing IAM Credentials from the Instance Metadata Service
+
+If the EC2 instance is configured to use the default [instance metadata service version 1](https://hackingthe.cloud/aws/general-knowledge/intro_metadata_service/#how-to-access-the-metadata-service), it is possible to steal IAM credentials from the instance without getting code execution on it.
+
+This can be done by abusing existing applications running on the host. By exploiting common vulnerabilities such as [server side request forgery](https://owasp.org/Top10/A10_2021-Server-Side_Request_Forgery_%28SSRF%29/) (SSRF) or [XML external entity](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing) (XXE) flaws, an adversary can coerce an application running on the host to retrieve those IAM credentials.
+
+To demonstrate this, in the following example there is a web server running on port 80 of the EC2 instance. This web server has a simple SSRF vulnerability, allowing us to make GET requests to arbitrary addresses. We can leverage this to make a request to `http://169.254.169.254`.
 
 <figure markdown>
   ![Showing SSRF](/images/aws/exploitation/ec2-metadata-ssrf/showing-ssrf.png){ loading=lazy }
 </figure>
 
-To determine if the EC2 instance has an IAM role associated with it, look for http://169.254.169.254/latest/meta-data/iam/. A 404 response indicates there is no IAM role associated. You may also get a 200 response that is empty, this indicates that there was an IAM Role however it has since been revoked.
+To determine if the EC2 instance has an IAM role associated with it, we can make a request to `http://169.254.169.254/latest/meta-data/iam/`. A 404 response indicates there is no IAM role associated. You may also get a 200 response that is empty, this indicates that there was an IAM Role however it has since been revoked.
 
-If there is a valid role you can steal, make a request to http://169.254.169.254/latest/meta-data/iam/security-credentials/. This will return the name of the IAM role the credentials represent. In the example below we see that the role name is 'ec2-default-ssm'.
+If there is a valid role we can steal, we can make a request to `http://169.254.169.254/latest/meta-data/iam/security-credentials/`. This will return the name of the IAM role associated with the credentials. In the example below we see that the role name is 'ec2-default-ssm'.
 
 <figure markdown>
   ![Role Name](/images/aws/exploitation/ec2-metadata-ssrf/role-name.png){ loading=lazy }
 </figure>
 
-To steal the credentials, append the role name to your previous query. For example, with the name above we'd query http://169.254.169.254/latest/meta-data/iam/security-credentials/ec2-default-ssm/.
+To retrieve the credentials, we can append the role name to the previous query. For example, with the role name shown previously, the query would be `http://169.254.169.254/latest/meta-data/iam/security-credentials/ec2-default-ssm/`.
 
 <figure markdown>
   ![Stolen Keys](/images/aws/exploitation/ec2-metadata-ssrf/stolen-keys.png){ loading=lazy }
 </figure>
 
-These credentials can then be used in the AWS CLI or other means to make API calls as the IAM role.
+These credentials can then be used in the AWS CLI to make calls to the API. To learn more about using stolen IAM credentials, check out this comprehensive [guide](https://hackingthe.cloud/aws/general-knowledge/using_stolen_iam_credentials/).
+
+!!! Note
+    An adversary who has gained code execution on the EC2 instance can retrieve credentials from the IMDS regardless of the version being used. Therefore, it is important to continually monitor your environment for suspicious activities.

--- a/content/aws/exploitation/ec2-metadata-ssrf.md
+++ b/content/aws/exploitation/ec2-metadata-ssrf.md
@@ -47,3 +47,9 @@ These credentials can then be used in the AWS CLI to make calls to the API. To l
 
 !!! Note
     An adversary who has gained code execution on the EC2 instance can retrieve credentials from the IMDS regardless of the version being used. Therefore, it is important to continually monitor your environment for suspicious activities.
+
+## Additional Resources
+
+For an example of this technique being used in the wild along with additional information, please see Kevin Fang's excellent [video](https://www.youtube.com/watch?v=r7HV4s-4ksQ) on the 2019 Capital One breach.
+
+<center><iframe width="560" height="315" src="https://www.youtube.com/embed/r7HV4s-4ksQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></center>


### PR DESCRIPTION
I happened to see the [Steal EC2 Metadata Credentials via SSRF](https://hackingthe.cloud/aws/exploitation/ec2-metadata-ssrf/) article mentioned in a [YouTube](https://www.youtube.com/watch?v=r7HV4s-4ksQ) video and got excited! I then re-read the article and was disappointed. 

This was one of the first articles I ever wrote for the site, and it is clearly showing its age. Particularly with the quality of the writing. Because this is one of the most popular pages on the entire site, I an opening this PR to improve it.