### PR TITLE
Fixed the order of the Enumerate IAM User/Role article

### DIFF
--- a/content/aws/enumeration/enum_iam_user_role.md
+++ b/content/aws/enumeration/enum_iam_user_role.md
@@ -6,13 +6,13 @@ hide:
   - toc
 ---
 
+# Unauthenticated Enumeration of IAM Users and Roles  
+
 Original Research: [Daniel Grzelak](https://twitter.com/dagrz) - [Remastered Talk by Scott Piper](https://www.youtube.com/watch?v=8ZXRw4Ry3mQ)  
 Additional Reading: [Rhino Security](https://rhinosecuritylabs.com/aws/aws-role-enumeration-iam-p2/)  
 Link to Quiet Riot: [Github](https://github.com/righteousgambitresearch/quiet-riot)  
 Link to Tool: [GitHub](https://github.com/Frichetten/enumate_iam_using_bucket_policy)  
 Link to Pacu Module: [GitHub](https://github.com/RhinoSecurityLabs/pacu/tree/master/pacu/modules/iam__enum_roles)  
-
-# Unauthenticated Enumeration of IAM Users and Roles
 
 You can enumerate AWS Account IDs, Root User account e-mail addresses, IAM roles, IAM users, and gain insights to enabled AWS and third-party services by abusing [Resource-Based Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based), even in accounts for which you have no access. [Quiet Riot](https://github.com/righteousgambitresearch/quiet-riot) offers a scalable method for enumerating each of these items with configurable wordlists per item type. Furthermore - it also allows you to enumerate Azure Active Directory and Google Workspace valid email addresses - which can then be used to test for valid Root User accounts in AWS, assuming that the email address is the same.
 

--- a/content/aws/enumeration/enum_iam_user_role.md
+++ b/content/aws/enumeration/enum_iam_user_role.md
@@ -6,15 +6,15 @@ hide:
   - toc
 ---
 
-# Unauthenticated Enumeration of IAM Users and Roles
-
-You can enumerate AWS Account IDs, Root User account e-mail addresses, IAM roles, IAM users, and gain insights to enabled AWS and third-party services by abusing [Resource-Based Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based), even in accounts for which you have no access. [Quiet Riot](https://github.com/righteousgambitresearch/quiet-riot) offers a scalable method for enumerating each of these items with configurable wordlists per item type. Furthermore - it also allows you to enumerate Azure Active Directory and Google Workspace valid email addresses - which can then be used to test for valid Root User accounts in AWS, assuming that the email address is the same.
-
 Original Research: [Daniel Grzelak](https://twitter.com/dagrz) - [Remastered Talk by Scott Piper](https://www.youtube.com/watch?v=8ZXRw4Ry3mQ)  
 Additional Reading: [Rhino Security](https://rhinosecuritylabs.com/aws/aws-role-enumeration-iam-p2/)  
 Link to Quiet Riot: [Github](https://github.com/righteousgambitresearch/quiet-riot)  
 Link to Tool: [GitHub](https://github.com/Frichetten/enumate_iam_using_bucket_policy)  
 Link to Pacu Module: [GitHub](https://github.com/RhinoSecurityLabs/pacu/tree/master/pacu/modules/iam__enum_roles)  
+
+# Unauthenticated Enumeration of IAM Users and Roles
+
+You can enumerate AWS Account IDs, Root User account e-mail addresses, IAM roles, IAM users, and gain insights to enabled AWS and third-party services by abusing [Resource-Based Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based), even in accounts for which you have no access. [Quiet Riot](https://github.com/righteousgambitresearch/quiet-riot) offers a scalable method for enumerating each of these items with configurable wordlists per item type. Furthermore - it also allows you to enumerate Azure Active Directory and Google Workspace valid email addresses - which can then be used to test for valid Root User accounts in AWS, assuming that the email address is the same.
 
 Ultimately, if you want to perform these techniques at scale - Quiet Riot is your best best, but if you want to do it manually, you can a number of ways to do so. Another way to enumerate IAM principals would be to use S3 Bucket Policies. Take the following example:
 


### PR DESCRIPTION
While working today I noticed that the resources section was not in the right order with the introductory paragraph. I have switched them out and it should be good now.