### PR TITLE
Added a code block to the CONTRIBUTING page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ If you'd like to use a card, for [example](https://hackingthe.cloud/aws/post_exp
 
 ### Card Templates
 
+```
 <div class="grid cards" markdown>
 
 -   :material-tools:{ .lg .middle } __Tools mentioned in this article__
@@ -72,6 +73,7 @@ If you'd like to use a card, for [example](https://hackingthe.cloud/aws/post_exp
     Reference: []()
 
 </div>
+```
 
 ## Creating a New Page
 


### PR DESCRIPTION
I realized that if you were using GitHub only then the card templates would be rendered already, so you wouldn't know what to copy. I put them in a code block to account for this.