### PR TITLE
Revert "Added custom background color"

### DIFF
--- a/content/stylesheets/extra.css
+++ b/content/stylesheets/extra.css
@@ -1,3 +1,0 @@
-[data-md-color-scheme="slate"] {
-  background: #2e303e;
-}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,9 +58,6 @@ plugins:
 extra_javascript:
   - javascripts/matomo.min.js
 
-extra_css:
-  - stylesheets/extra.css
-
 repo_name: Hacking The Cloud
 repo_url: https://github.com/Hacking-the-Cloud/hackingthe.cloud
 edit_uri: edit/main/content/


### PR DESCRIPTION
This reverts commit c947a67533c4738130e0dca29ccc65ff0810f549. I botched the color changes in multiple ways. This also made me realize that if changes are made around the colors (For example, MKDocs adds something new) then my stuff may look hella jank. I'm going to explore the [hue](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#custom-color-schemes) stuff from the documentation to see if that helps.