### PR TITLE
Added intro to local_ec2_priv_esc_through_user_data

### DIFF
--- a/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
+++ b/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
@@ -4,6 +4,8 @@ title: EC2 Privilege Escalation Through User Data
 description: How to escalate privileges on an EC2 instance by abusing user data.
 ---
 
+If you've gained a foothold on an EC2 instance, use these these techniques to escalate privileges to root/System on the host.
+
 ## ec2:ModifyInstanceAttribute
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
I wanted to make it more clear that these techniques are for privilege escalation on an EC2 instance, and not in the AWS account (IAM priv esc). I added an intro to compensate for this.