### PR TITLE
Remove Broken Link in Domain Takeover

### DIFF
--- a/content/aws/exploitation/orphaned_cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_cloudfront_or_dns_takeover_via_s3.md
@@ -10,6 +10,12 @@ hide:
 
 <div class="grid cards" markdown>
 
+-   :material-book:{ .lg .middle } __Additional Resources__
+
+    ---
+
+    [Discover Dangling Domains that point to your cloud assets to prevent subdomain takeover](https://web.archive.org/web/20231210202023/https://blog.lightspin.io/discover-dangling-domains-that-point-to-your-cloud-assets-to-prevent-subdomain-takeover)
+
 -   :material-tools:{ .lg .middle } __Tools mentioned in this article__
 
     ---

--- a/content/aws/exploitation/orphaned_cloudfront_or_dns_takeover_via_s3.md
+++ b/content/aws/exploitation/orphaned_cloudfront_or_dns_takeover_via_s3.md
@@ -10,12 +10,6 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-book:{ .lg .middle } __Additional Resources__
-
-    ---
-
-    [Discover Dangling Domains that point to your cloud assets to prevent subdomain takeover](https://blog.lightspin.io/discover-dangling-domains-that-point-to-your-cloud-assets-to-prevent-subdomain-takeover)
-
 -   :material-tools:{ .lg .middle } __Tools mentioned in this article__
 
     ---


### PR DESCRIPTION
In [DNS and CloudFront Domain Takeover via Deleted S3 Buckets](http://localhost:8000/aws/exploitation/orphaned_cloudfront_or_dns_takeover_via_s3/) doc there is a broken link referencing `Discover Dangling Domains that point to your cloud assets to prevent subdomain takeover` which is no longer available. It seems (assumption, having not read the original) that the article has been archived [here](https://securityboulevard.com/2023/05/discover-dangling-domains-that-point-to-your-cloud-assets-to-prevent-subdomain-takeover/). I don't know if Hacking The Cloud wants to reference that archive, another in its place, or anything. For now just removing the reference.

I think this was probably broken since Cisco acquired lightspin.io.