### PR TITLE
update: Add cloud-boothook tip for user data

### DIFF
--- a/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
+++ b/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
@@ -33,7 +33,12 @@ If you've gained a foothold on an EC2 instance, use these these techniques to es
 
 If an adversary has access to the modify-instance attribute permission they can leverage it to escalate to root/System on an EC2 instance.
 
-Usually, user data scripts are only run the first time the instance is started, however this can be changed using [cloud-init](https://aws.amazon.com/premiumsupport/knowledge-center/execute-user-data-ec2/) to run every time the instance restarts.
+Usually, user data scripts are only run the first time the instance is started. 
+
+One trick to bypass this limitation uses [the `#cloud-boothook` directive](https://docs.aws.amazon.com/linux/al2/ug/amazon-linux-cloud-init.html), which instructs the instance to run the code on each boot.
+
+
+An alternative approach uses a special [cloud-init](https://aws.amazon.com/premiumsupport/knowledge-center/execute-user-data-ec2/) `cloud-config` to prompt a run every time the instance restarts.
 
 To do this, first create a file in the following format.
 

--- a/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
+++ b/content/aws/exploitation/local_ec2_priv_esc_through_user_data.md
@@ -37,7 +37,6 @@ Usually, user data scripts are only run the first time the instance is started.
 
 One trick to bypass this limitation uses [the `#cloud-boothook` directive](https://docs.aws.amazon.com/linux/al2/ug/amazon-linux-cloud-init.html), which instructs the instance to run the code on each boot.
 
-
 An alternative approach uses a special [cloud-init](https://aws.amazon.com/premiumsupport/knowledge-center/execute-user-data-ec2/) `cloud-config` to prompt a run every time the instance restarts.
 
 To do this, first create a file in the following format.


### PR DESCRIPTION
Throwing this up, but let me know if I'm missing something - we're outside my wheelhouse :).

My understanding is `#cloud-boothook` is a straightforwardly better approach than the current documented `cloud-config`, and also is what dagrz uses in the linked source