### PR TITLE
Deprecate Claude magic string article

### DIFF
--- a/content/ai-llm/.pages
+++ b/content/ai-llm/.pages
@@ -1,2 +1,2 @@
 nav:
-    - Exploitation: exploitation
+    - Deprecated: deprecated

--- a/content/ai-llm/deprecated/claude_magic_string_denial_of_service.md
+++ b/content/ai-llm/deprecated/claude_magic_string_denial_of_service.md
@@ -1,10 +1,13 @@
 ---
 author_name: Nick Frichette
-title: Break LLM Workflows with Claude's Refusal Magic String
+title: "[Deprecated] Break LLM Workflows with Claude's Refusal Magic String"
 description: How Anthropic's refusal test string can be abused to stop streaming responses and create sticky failures.
 ---
 
-# Claude Magic String Denial of Service
+# [Deprecated] Claude Magic String Denial of Service
+
+!!! Warning
+    As of May 2026, Anthropic has patched this behavior. The magic string no longer triggers the API error described below, so this technique should be considered deprecated. This page is maintained for historical and inspiration purposes.
 
 <div class="grid cards" markdown>
 -   :material-account:{ .lg .middle } __Original Research__

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ plugins:
   - redirects:
       redirect_maps:
         'aws/post_exploitation/aws_consoler.md': 'aws/post_exploitation/create_a_console_session_from_iam_credentials.md'
+        'ai-llm/exploitation/claude_magic_string_denial_of_service.md': 'ai-llm/deprecated/claude_magic_string_denial_of_service.md'
   - glightbox: # non-standard
 
 extra_javascript:


### PR DESCRIPTION
## Summary
- Move the Claude magic string denial-of-service article into the AI/LLM deprecated section
- Add a prominent deprecation warning noting Anthropic patched the behavior as of May 2026
- Add a redirect from the old exploitation article path to the new deprecated path

## Validation
- git diff --cached --check
- docker run --rm -v /Users/nick/Documents/hackingthe.cloud:/docs mkdocs-material build --strict --site-dir /tmp/htc-pr-site