### PR TITLE
[codex] migrate MkDocs Material build

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install "mkdocs-material>=9.7.0"
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-awesome-pages-plugin
       - run: pip install mkdocs-redirects

--- a/.github/workflows/deploy_v2.yml
+++ b/.github/workflows/deploy_v2.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +25,7 @@ jobs:
             mkdocs-material-
       - run: sudo apt-get update
       - run: sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
-      - run: pip install pillow cairosvg
+      - run: pip install "mkdocs-material[imaging]>=9.7.0"
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-awesome-pages-plugin
       - run: pip install mkdocs-redirects
@@ -33,5 +33,4 @@ jobs:
       - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-rss-plugin
       - run: pip install --use-pep517 mkdocs-glightbox
-      - run: pip install git+https://${{ secrets.GH_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
-      - run: mkdocs gh-deploy --force --config-file mkdocs.insiders.yml
+      - run: mkdocs gh-deploy --force --config-file mkdocs.deploy.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ __NOTE__: You do not have to run the Docker container to contribute. You can mak
 
 ## Using Cards
 
-If you'd like to use a card, for [example](https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/) `Technique seen in the wild`, `Tools mentioned in this article`, etc, __please be aware that you would need a subscription for [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/reference/grids/#using-card-grids) for the cards to be properly displayed on your local machine__. Simply copy and paste the template from the options below and it will be properly rendered on the site (we have a subscription to Material for MKDocs).
+If you'd like to use a card, for [example](https://hackingthe.cloud/aws/post_exploitation/create_a_console_session_from_iam_credentials/) `Technique seen in the wild`, `Tools mentioned in this article`, etc, copy and paste the template from the options below. Cards are supported by the public Material for MkDocs package used by the site.
 
 ### Card Templates
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,17 +1,13 @@
-# This Dockerfile is intended for local testing and requires a subscription to 
-# Material for MkDocs to work. If you'd like to contribute to Hacking the Cloud
-# and need to setup a local env, you can use the normal "Dockerfile" in this repo.
-# Thank you!
+# This Dockerfile matches the deploy workflow, including social cards and
+# deploy-only MkDocs plugins.
 FROM ubuntu
-
-ARG GH_TOKEN
 
 WORKDIR /docs
 
 RUN apt update -y
 RUN apt install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev python3-pip python3 git
 RUN pip install tzdata
-RUN pip install pillow cairosvg
+RUN pip install "mkdocs-material[imaging]>=9.7.0"
 RUN pip install mkdocs-minify-plugin
 RUN pip install mkdocs-awesome-pages-plugin
 RUN pip install mkdocs-redirects
@@ -19,7 +15,6 @@ RUN pip install mkdocs-git-revision-date-localized-plugin
 RUN pip install mkdocs-git-committers-plugin-2
 RUN pip install mkdocs-rss-plugin
 RUN pip install --use-pep517 mkdocs-glightbox
-RUN pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
 
 RUN git config --global --add safe.directory /docs &&\
     git config --global --add safe.directory /site

--- a/mkdocs.deploy.yml
+++ b/mkdocs.deploy.yml
@@ -1,8 +1,8 @@
 INHERIT: mkdocs.yml
 plugins:
-  - social: # Added to .insiders.yml
-        cards_layout_dir: layouts
-        cards_layout: custom
+  - social:
+      cards_layout_dir: layouts
+      cards_layout: custom
   - search
   - rss: # non-standard
       length: 200


### PR DESCRIPTION
## Summary

- Replace the deleted mkdocs-material-insiders install in deploy CI with the public mkdocs-material[imaging]>=9.7.0 package.
- Rename the deploy-specific MkDocs config from mkdocs.insiders.yml to mkdocs.deploy.yml.
- Update local deploy Dockerfile and contribution docs to remove stale Insiders/subscription assumptions.

## Root cause

The deploy workflow was still cloning squidfunk/mkdocs-material-insiders, which now returns Repository not found after Material for MkDocs made Insiders features available in the public package.

## Validation

- mkdocs build --site-dir /private/tmp/htc-site-default
- mkdocs build --config-file mkdocs.deploy.yml --site-dir /private/tmp/htc-site-deploy

The deploy-config local build completed with public mkdocs-material 9.7.6. The unauthenticated local run hit the existing git-committers GitHub API rate limit, but CI now provides GH_TOKEN via github.token.