### PR TITLE
[codex] fix deploy redirects

### DIFF
--- a/mkdocs.deploy.yml
+++ b/mkdocs.deploy.yml
@@ -18,4 +18,8 @@ plugins:
       minify_html: true
       minify_js: true
       minify_css: true
+  - redirects:
+      redirect_maps:
+        'aws/post_exploitation/aws_consoler.md': 'aws/post_exploitation/create_a_console_session_from_iam_credentials.md'
+        'ai-llm/exploitation/claude_magic_string_denial_of_service.md': 'ai-llm/deprecated/claude_magic_string_denial_of_service.md'
   - glightbox: # non-standard


### PR DESCRIPTION
## Summary
- Add the existing redirect map to mkdocs.deploy.yml, which is the config used by the production deploy workflow
- Fix the Claude magic string old-path redirect generation for gh-pages

## Root Cause
The production deploy config defines its own list-style plugins block. MkDocs inheritance replaces list values, so the redirects plugin from mkdocs.yml was not active during the deploy build.

## Validation
- git diff --check
- docker run with mkdocs.deploy.yml confirmed the old article path generates a redirect index.html pointing to ../../deprecated/claude_magic_string_denial_of_service/
- docker run with mkdocs.yml completed a strict build