### PR TITLE
[codex] restore default header

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  The CFP for 
-  <a rel="me" href="https://fwdcloudsec.org/conference/europe/cfp.html">
-    <strong>fwd:cloudsec EU 2026</strong>
-  </a> is open now! This is your opportunity to speak at the best cloud security conference on earth!
+  For updates follow <strong>Nick Frichette</strong> on
+  <a rel="me" href="https://bsky.app/profile/frichetten.com">
+    <span class="twemoji bluesky">
+      {% include ".icons/fontawesome/brands/bluesky.svg" %}
+    </span>
+    <strong>Bluesky</strong>
+  </a>.
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary

Restores the site announcement header from the fwd:cloudsec EU 2026 CFP advertisement back to the default Nick Frichette Bluesky follow banner.

## Why

The CFP promotion is no longer the desired default header. The restored block matches the prior default from `overrides/main.html` history before the CFP advert was added.

## Impact

Visitors will again see the standard follow banner in the MkDocs Material announcement area.

## Validation

- `git diff --check -- overrides/main.html`
- `git diff --check HEAD^ HEAD`

Note: full Docker preview was not run; this is a single template text/link restoration.
