### PR TITLE
add Twitter to header

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,6 +7,13 @@
       {% include ".icons/fontawesome/brands/bluesky.svg" %}
     </span>
     <strong>Bluesky</strong>
+  </a>
+  and
+  <a href="https://twitter.com/frichette_n">
+    <span class="twemoji twitter">
+      {% include ".icons/fontawesome/brands/twitter.svg" %}
+    </span>
+    <strong>Twitter</strong>
   </a>.
 {% endblock %}
 


### PR DESCRIPTION
## Summary

Adds Twitter back to the site announcement header alongside the existing Bluesky link.

## Validation

- `git diff --check -- overrides/main.html`
- `git diff --check HEAD^ HEAD`
- `curl -L --silent --max-time 20 -o /private/tmp/bsky-profile-check.html -w '%{http_code} %{url_effective}\n' https://bsky.app/profile/frichetten.com` returned `200 https://bsky.app/profile/frichetten.com`
- `curl -L --silent --max-time 20 -o /private/tmp/twitter-profile-check.html -w '%{http_code} %{url_effective}\n' https://twitter.com/frichette_n` returned `200 https://x.com/frichette_n`
- Bluesky handle resolution returned a DID for `frichetten.com`

Docker/MkDocs preview was not run because the local Docker daemon is not running and `mkdocs` is not installed locally.